### PR TITLE
Update and rename start.docker to init.docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ chmod +x init.docker
 ```
 
 from the root diectory. This will:
-   1. Automatically create allora keys for you. You will have to request for some tokens from faucet to be able to register your worker and stake your reputer. You can find your address in ./data/env_file
-   2. Automatically export the needed variables from the account created to be used by the offchain node and bundles it with the your provided config.json and then pass them to the node as environemnt variable
+   - Automatically create allora keys for you. You will have to request for some tokens from faucet to be able to register your worker and stake your reputer. You can find your address in ./data/env_file
+   - Automatically export the needed variables from the account created to be used by the offchain node and bundles it with the your provided config.json and then pass them to the node as environemnt variable
 
 5. Run `docker compose up -d`. This will:
    - Run the both the offchain node and the source services, communicating through endpoints attached to the internal dns

--- a/README.md
+++ b/README.md
@@ -10,16 +10,22 @@ Allora off-chain nodes publish inferences, forecasts, and losses informed by a c
 ```shell
 cp config.example.json config.json
 ```
-4. Run docker compose from the root diectory. This will:
+4. Run
+
+```shell
+chmod +x init.docker
+./init.docker 
+```
+
+from the root diectory. This will:
    1. Automatically create allora keys for you. You will have to request for some tokens from faucet to be able to register your worker and stake your reputer. You can find your address in ./data/env_file
    2. Automatically export the needed variables from the account created to be used by the offchain node and bundles it with the your provided config.json and then pass them to the node as environemnt variable
-   3. Run the both the offchain node and the source services, communicating through endpoints attached to the internal dns
+
+5. Run `docker compose up -d`. This will:
+   - Run the both the offchain node and the source services, communicating through endpoints attached to the internal dns
 
 Please note that the environment variable will be created as bumdle of your config.json and allora account secrets, please make sure to remove every sectrets before commiting to remote git repository
-```shell
-chmod +x start.docker
-./start.docker 
-```
+
 
 ## How to run without docker
 

--- a/init.docker
+++ b/init.docker
@@ -14,4 +14,3 @@ else
     echo "config.json is already loaded, skipping the operation. You can set ENV_LOADED variable to false in ./data/env_file to reload the config.json"
 fi
 
-docker compose up --build


### PR DESCRIPTION
on devnet, when running the command:

chmod +x start.docker
./start.docker

 the worker node won't register because it is not funded. The wallet for the worker node is being created and the node is attempting to register to the network in one go. However, for the user this will never work. What they will have to do is
1. run the command
2. kill the terminal
3. fund their wallet
4. rerun the chmod command

The fix proposed is:

1. run`init.docker` to generate address and then you can get the address funded manually
2. run `docker compose up --build` separately to start your services