### PR TITLE
Loss Function library usage - initial impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) for all versions `v1.0.0` and beyond (still considered experimental prior to v1.0.0).
 
-## [Unreleased]
+## v0.5.0
+
+### Added
+
+* [#63](https://github.com/allora-network/allora-offchain-node/pull/63) Loss Function Library support.
+
+### Removed
+
+### Fixed
+
+### Security
+* [#62](https://github.com/allora-network/allora-offchain-node/pull/62) Fix security email
+
+
+## v0.4.0
 
 ### Added
 

--- a/adapter/api/source/main.py
+++ b/adapter/api/source/main.py
@@ -12,10 +12,12 @@ class NodeValue:
 def health():
     return "Hello, World, I'm alive!"
 
+
 @app.route('/inference/<token>', methods=['GET'])
 def get_inference(token):
     random_float = str(random.uniform(0.0, 100.0))
     return random_float
+
 
 @app.route('/forecast', methods=['GET'])
 def get_forecast():
@@ -26,10 +28,22 @@ def get_forecast():
     ]
     return jsonify([nv.__dict__ for nv in node_values])
 
+
 @app.route('/truth/<token>/<blockheight>', methods=['GET'])
 def get_truth(token, blockheight):
     random_float = str(random.uniform(0.0, 100.0))
     return random_float
+
+
+@app.route('/is_never_negative', methods=['POST'])
+def is_never_negative():
+    return True
+
+
+@app.route('/calculate', methods=['POST'])
+def calculate_loss():
+    return "1.0"
+
 
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0', port=8000)

--- a/adapter/api/worker-reputer/README.md
+++ b/adapter/api/worker-reputer/README.md
@@ -25,24 +25,44 @@ Worker: []lib.WorkerConfig{
 },
 ```
 
-Example as Reputer: 
+Example as Reputer ("gt" in this context means "ground truth"): 
 ```
 Reputer: []lib.ReputerConfig{
     {
-        TopicId:           1,
-        ReputerEntrypoint: apiAdapter.NewAlloraAdapter(),
-        LoopSeconds:       30,
-        MinStake:          100000,
-        Parameters: map[string]string{
-            "SourceOfTruthEndpoint": "http://localhost:8000/groundtruth/{Token}/{BlockHeight}",
-            "Token":                 "ethereum",
+        "topicId": 1,
+        "groundTruthEntrypointName": "api-worker-reputer",
+        "lossFunctionEntrypointName": "api-worker-reputer",
+        "loopSeconds": 30,
+        "minStake": 100000,
+        "groundTruthParameters": {
+          "GroundTruthEndpoint": "http://localhost:8888/gt/{Token}/{BlockHeight}",
+          "Token": "ETHUSD"
         },
-    },
+        "lossFunctionParameters": {
+          "LossFunctionService": "http://localhost:5000",
+          "LossMethodOptions": {
+            "loss_method": "huber",
+            "delta": "1.0"
+          }
+        }
+    }
 },
 ```
 
-## Parameters 
+## Parameters
+
 The parameters section contains additional properties the user wants to use to configure their URLs to hit.
+In the case of the reputer, there are two parameters sections, one for the ground truth and one for the loss function.
+In particular, the `LossMethodOptions` are specific to the loss function and passed unconverted to the loss function service.
+They can be used to pass additional parameters to the loss function service. For example, the `delta` parameter is passed to the huber loss function like this (or as per defined in the loss function service of choice): 
+
+```
+"LossMethodOptions": {
+    "loss_method": "huber",
+    "delta": "1.0"
+}
+```
+
 
 ### Worker
 
@@ -59,7 +79,10 @@ InferenceEntrypoint: nil
 
 ### Reputer
 
-`SourceOfTruthEndpoint`is required if `ReputerEntrypoint` is defined.
+Two endpoints are required:
+* `GroundTruthEndpoint`: provides the ground truth endpoint to hit. It does support template variables.
+* `LossFunctionService`: provides the loss function service to hit on loss calculation and the endpoint to know whether the loss function is never negative. These are appended to create `/calculate` and `/is_never_negative` endpoints respectively. They do not support template variables.
+
 
 ### Additional Parameters 
 

--- a/config.cdk.json.template
+++ b/config.cdk.json.template
@@ -24,12 +24,19 @@
     "reputer": [
       {
         "topicId": _ALLORA_REPUTER_TOPIC_ID_,
-        "reputerEntrypointName": "_ALLORA_REPUTER_ENTRYPOINT_NAME_",
+        "groundTruthEntrypointName": "_ALLORA_REPUTER_ENTRYPOINT_NAME_",
+        "lossFunctionEntrypointName": "_ALLORA_REPUTER_ENTRYPOINT_NAME_",
         "loopSeconds": _ALLORA_REPUTER_LOOP_SECONDS_,
         "minStake": _ALLORA_REPUTER_MIN_STAKE_,
-        "parameters": {
-          "SourceOfTruthEndpoint": "_ALLORA_REPUTER_SOURCE_OF_TRUTH_ENDPOINT_",
+        "groundTruthParameters": {
+          "GroundTruthEndpoint": "_ALLORA_REPUTER_SOURCE_OF_TRUTH_ENDPOINT_",
           "Token": "_ALLORA_REPUTER_TOKEN_"
+        },
+        "lossFunctionParameters": {
+          "LossFunctionService": "_ALLORA_REPUTER_LOSS_FUNCTION_SERVICE_",
+          "LossMethodOptions": {
+            "loss_method": "_ALLORA_REPUTER_LOSS_METHOD_OPTIONS_LOSS_METHOD_"
+          }
         }
       }
     ]

--- a/config.example.json
+++ b/config.example.json
@@ -1,7 +1,7 @@
 {
     "wallet": {
       "addressKeyName": "testkey",
-      "addressRestoreMnemonic": "",
+      "addressRestoreMnemonic": "your mnemonic here",
       "alloraHomeDir": "",
       "gas": "auto",
       "gasAdjustment": 1.5,
@@ -10,6 +10,17 @@
       "delay": 1,
       "submitTx": true
     },
+    "worker": [
+      {
+        "topicId": 1,
+        "inferenceEntrypointName": "api-worker-reputer",
+        "loopSeconds": 10,
+        "parameters": {
+          "InferenceEndpoint": "http://source:8000/inference/{Token}",
+          "Token": "ETH"
+        }
+      }
+    ],
     "reputer": [
       {
         "topicId": 1,

--- a/config.example.json
+++ b/config.example.json
@@ -1,35 +1,31 @@
 {
     "wallet": {
-      "addressKeyName": "test",
+      "addressKeyName": "testkey",
       "addressRestoreMnemonic": "",
       "alloraHomeDir": "",
       "gas": "auto",
       "gasAdjustment": 1.5,
-      "nodeRpc": "http://localhost:26657",
+      "nodeRpc": "https://allora-rpc.testnet.allora.network",
       "maxRetries": 1,
       "delay": 1,
       "submitTx": true
     },
-    "worker": [
-      {
-        "topicId": 1,
-        "inferenceEntrypointName": "api-worker-reputer",
-        "loopSeconds": 10,
-        "parameters": {
-          "InferenceEndpoint": "http://source:8000/inference/{Token}",
-          "Token": "ETH"
-        }
-      }
-    ],
     "reputer": [
       {
         "topicId": 1,
-        "reputerEntrypointName": "api-worker-reputer",
+        "groundTruthEntrypointName": "api-worker-reputer",
+        "lossFunctionEntrypointName": "api-worker-reputer",
         "loopSeconds": 30,
         "minStake": 100000,
-        "parameters": {
-          "SourceOfTruthEndpoint": "http://source:8000/truth/{Token}/{BlockHeight}",
-          "Token": "ethereum"
+        "groundTruthParameters": {
+          "GroundTruthEndpoint": "http://localhost:8888/gt/{Token}/{BlockHeight}",
+          "Token": "ETHUSD"
+        },
+        "lossFunctionParameters": {
+          "LossFunctionService": "http://localhost:5000",
+          "LossMethodOptions": {
+            "loss_method": "sqe"
+          }
         }
       }
     ]

--- a/lib/domain_config.go
+++ b/lib/domain_config.go
@@ -64,6 +64,7 @@ type ReputerConfig struct {
 type LossFunctionParameters struct {
 	LossFunctionService string
 	LossMethodOptions   map[string]string
+	IsNeverNegative     *bool // Cached result of whether the loss function is never negative
 }
 
 type UserConfig struct {

--- a/lib/domain_config.go
+++ b/lib/domain_config.go
@@ -39,8 +39,7 @@ type WorkerConfig struct {
 	InferenceEntrypoint     AlloraAdapter
 	ForecastEntrypointName  string
 	ForecastEntrypoint      AlloraAdapter
-	LoopSeconds             int64 // seconds to wait between attempts to get next worker nonce
-	AllowsNegativeValue     bool
+	LoopSeconds             int64             // seconds to wait between attempts to get next worker nonce
 	Parameters              map[string]string // Map for variable configuration values
 }
 

--- a/lib/domain_config.go
+++ b/lib/domain_config.go
@@ -45,17 +45,25 @@ type WorkerConfig struct {
 }
 
 type ReputerConfig struct {
-	TopicId               emissions.TopicId
-	ReputerEntrypointName string
-	ReputerEntrypoint     AlloraAdapter
+	TopicId                    emissions.TopicId
+	GroundTruthEntrypointName  string
+	GroundTruthEntrypoint      AlloraAdapter
+	LossFunctionEntrypointName string
+	LossFunctionEntrypoint     AlloraAdapter
 	// Minimum stake to repute. will try to add stake from wallet if current stake is less than this.
 	// Will not repute if current stake is less than this, after trying to add any necessary stake.
 	// This is idempotent in that it will not add more stake than specified here.
 	// Set to 0 to effectively disable this feature and use whatever stake has already been added.
-	MinStake            int64
-	LoopSeconds         int64 // seconds to wait between attempts to get next reptuer nonces
-	AllowsNegativeValue bool
-	Parameters          map[string]string // Map for variable configuration values
+	MinStake               int64
+	LoopSeconds            int64 // seconds to wait between attempts to get next reptuer nonces
+	AllowsNegativeValue    bool
+	GroundTruthParameters  map[string]string      // Map for variable configuration values
+	LossFunctionParameters LossFunctionParameters // Map for variable configuration values
+}
+
+type LossFunctionParameters struct {
+	LossFunctionService string
+	LossMethodOptions   map[string]string
 }
 
 type UserConfig struct {
@@ -106,8 +114,8 @@ func (c *UserConfig) ValidateConfigAdapters() {
 	}
 
 	for _, reputerConfig := range c.Reputer {
-		if reputerConfig.ReputerEntrypoint != nil && !reputerConfig.ReputerEntrypoint.CanSourceTruthAndComputeLoss() {
-			log.Fatal().Interface("entrypoint", reputerConfig.ReputerEntrypoint).Msg("Invalid loss entrypoint")
+		if reputerConfig.GroundTruthEntrypoint != nil && !reputerConfig.GroundTruthEntrypoint.CanSourceGroundTruthAndComputeLoss() {
+			log.Fatal().Interface("entrypoint", reputerConfig.GroundTruthEntrypoint).Msg("Invalid loss entrypoint")
 		}
 	}
 }

--- a/lib/domain_config.go
+++ b/lib/domain_config.go
@@ -55,8 +55,7 @@ type ReputerConfig struct {
 	// This is idempotent in that it will not add more stake than specified here.
 	// Set to 0 to effectively disable this feature and use whatever stake has already been added.
 	MinStake               int64
-	LoopSeconds            int64 // seconds to wait between attempts to get next reptuer nonces
-	AllowsNegativeValue    bool
+	LoopSeconds            int64                  // seconds to wait between attempts to get next reptuer nonces
 	GroundTruthParameters  map[string]string      // Map for variable configuration values
 	LossFunctionParameters LossFunctionParameters // Map for variable configuration values
 }

--- a/lib/domain_entrypoint.go
+++ b/lib/domain_entrypoint.go
@@ -6,11 +6,12 @@ type AlloraAdapter interface {
 	Name() string
 	CalcInference(WorkerConfig, int64) (string, error)
 	CalcForecast(WorkerConfig, int64) ([]NodeValue, error)
-	SourceTruth(ReputerConfig, int64) (Truth, error) // to be interpreted on a per-topic basis
-	LossFunction(sourceTruth string, inferenceValue string) (string, error)
+	GroundTruth(ReputerConfig, int64) (Truth, error)
+	LossFunction(ReputerConfig, string, string, map[string]string) (string, error)
+	IsLossFunctionNeverNegative(ReputerConfig, map[string]string) (bool, error)
 	CanInfer() bool
 	CanForecast() bool
-	CanSourceTruthAndComputeLoss() bool
+	CanSourceGroundTruthAndComputeLoss() bool
 }
 
 type NodeValue struct {

--- a/lib/repo_tx_registration.go
+++ b/lib/repo_tx_registration.go
@@ -107,7 +107,7 @@ func (node *NodeConfig) RegisterAndStakeReputerIdempotently(config ReputerConfig
 	}
 	minStake := cosmossdk_io_math.NewInt(config.MinStake)
 	if minStake.LTE(stake) {
-		log.Error().Msg("Reputer stake below minimum stake, skipping.")
+		log.Info().Msg("Reputer stake above minimum requested stake, skipping adding stake.")
 		return true
 	}
 

--- a/lib/repo_tx_utils.go
+++ b/lib/repo_tx_utils.go
@@ -11,11 +11,15 @@ import (
 	"github.com/ignite/cli/v28/ignite/pkg/cosmosclient"
 )
 
+const ERROR_MESSAGE_EMA_ALREADY_SENT = "cannot update EMA"
+const ERROR_MESSAGE_TX_INCLUDED_IN_BLOCK = "waiting for next block"
+
 // SendDataWithRetry attempts to send data with a uniform backoff strategy for retries.
 // uniform backoff is preferred to avoid exiting the open submission windows
 func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg, successMsg string) (*cosmosclient.Response, error) {
 	var txResp *cosmosclient.Response
 	var err error
+	var hadEOFTxError bool
 	for retryCount := int64(0); retryCount <= node.Wallet.MaxRetries; retryCount++ {
 		txResponse, err := node.Chain.Client.BroadcastTx(ctx, node.Chain.Account, req)
 		txResp = &txResponse
@@ -23,9 +27,20 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 			log.Debug().Str("msg", successMsg).Str("txHash", txResp.TxHash).Msg("Success")
 			return txResp, nil
 		}
-		if strings.Contains(err.Error(), "cannot update EMA") {
-			log.Error().Err(err).Str("msg", successMsg).Msg("Already sent data for this epoch, no retry")
-			return nil, err
+		if strings.Contains(err.Error(), ERROR_MESSAGE_TX_INCLUDED_IN_BLOCK) {
+			if !hadEOFTxError {
+				hadEOFTxError = true
+				log.Warn().Err(err).Str("msg", successMsg).Msg("Tx sent, waiting for tx to be included in a block, retry")
+			}
+		}
+		if strings.Contains(err.Error(), ERROR_MESSAGE_EMA_ALREADY_SENT) {
+			if hadEOFTxError {
+				log.Info().Str("msg", successMsg).Msg("Confirmed previously sent tx accepted")
+				return nil, err
+			} else {
+				log.Info().Err(err).Str("msg", successMsg).Msg("Already sent data for this epoch, no retry")
+				return nil, err
+			}
 		}
 		// Log the error for each retry.
 		log.Error().Err(err).Str("msg", successMsg).Msgf("Failed, retrying... (Retry %d/%d)", retryCount, node.Wallet.MaxRetries)

--- a/main.go
+++ b/main.go
@@ -34,13 +34,24 @@ func ConvertEntrypointsToInstances(userConfig lib.UserConfig) error {
 	}
 
 	for i, reputer := range userConfig.Reputer {
-		if reputer.ReputerEntrypointName != "" {
-			adapter, err := NewAlloraAdapter(reputer.ReputerEntrypointName)
+		if reputer.GroundTruthEntrypointName != "" {
+			adapter, err := NewAlloraAdapter(reputer.GroundTruthEntrypointName)
 			if err != nil {
 				fmt.Println("Error creating reputer adapter:", err)
 				return err
 			}
-			userConfig.Reputer[i].ReputerEntrypoint = adapter
+			userConfig.Reputer[i].GroundTruthEntrypoint = adapter
+		}
+	}
+
+	for i, reputer := range userConfig.Reputer {
+		if reputer.LossFunctionEntrypointName != "" {
+			adapter, err := NewAlloraAdapter(reputer.LossFunctionEntrypointName)
+			if err != nil {
+				fmt.Println("Error creating reputer adapter:", err)
+				return err
+			}
+			userConfig.Reputer[i].LossFunctionEntrypoint = adapter
 		}
 	}
 	return nil

--- a/usecase/build_commit_reputer_payload.go
+++ b/usecase/build_commit_reputer_payload.go
@@ -30,7 +30,7 @@ func (suite *UseCaseSuite) BuildCommitReputerPayload(reputer lib.ReputerConfig, 
 	}
 	valueBundle.Reputer = suite.Node.Wallet.Address
 
-	sourceTruth, err := reputer.ReputerEntrypoint.SourceTruth(reputer, nonce)
+	sourceTruth, err := reputer.GroundTruthEntrypoint.GroundTruth(reputer, nonce)
 	if err != nil {
 		log.Error().Err(err).Uint64("topicId", reputer.TopicId).Msg("Failed to get source truth from reputer")
 		return false, err
@@ -86,11 +86,19 @@ func (suite *UseCaseSuite) ComputeLossBundle(sourceTruth string, vb *emissionsty
 	if IsEmpty(*vb) {
 		return emissionstypes.ValueBundle{}, errors.New("empty ValueBundle")
 	}
-	if err := ValidateDec(vb.CombinedValue); err != nil {
+	if err := emissionstypes.ValidateDec(vb.CombinedValue); err != nil {
 		return emissionstypes.ValueBundle{}, errors.New("ValueBundle - invalid CombinedValue")
 	}
-	if err := ValidateDec(vb.NaiveValue); err != nil {
+	if err := emissionstypes.ValidateDec(vb.NaiveValue); err != nil {
 		return emissionstypes.ValueBundle{}, errors.New("ValueBundle - invalid NaiveValue")
+	}
+
+	// Check if loss function is never negative
+	lossMethodOptions := reputer.LossFunctionParameters.LossMethodOptions
+	is_never_negative, err := reputer.LossFunctionEntrypoint.IsLossFunctionNeverNegative(reputer, lossMethodOptions)
+	if err != nil {
+		log.Error().Err(err).Msg("Error checking if loss function is never negative")
+		return emissionstypes.ValueBundle{}, err
 	}
 
 	losses := emissionstypes.ValueBundle{
@@ -101,7 +109,7 @@ func (suite *UseCaseSuite) ComputeLossBundle(sourceTruth string, vb *emissionsty
 	}
 
 	computeLoss := func(value alloraMath.Dec, description string) (alloraMath.Dec, error) {
-		lossStr, err := reputer.ReputerEntrypoint.LossFunction(sourceTruth, value.String())
+		lossStr, err := reputer.LossFunctionEntrypoint.LossFunction(reputer, sourceTruth, value.String(), lossMethodOptions)
 		if err != nil {
 			return alloraMath.Dec{}, fmt.Errorf("error computing loss for %s: %w", description, err)
 		}
@@ -111,14 +119,14 @@ func (suite *UseCaseSuite) ComputeLossBundle(sourceTruth string, vb *emissionsty
 			return alloraMath.Dec{}, fmt.Errorf("error parsing loss value for %s: %w", description, err)
 		}
 
-		if !reputer.AllowsNegativeValue {
+		if is_never_negative {
 			loss, err = alloraMath.Log10(loss)
 			if err != nil {
 				return alloraMath.Dec{}, fmt.Errorf("error Log10 for %s: %w", description, err)
 			}
 		}
 
-		if err := ValidateDec(loss); err != nil {
+		if err := emissionstypes.ValidateDec(loss); err != nil {
 			return alloraMath.Dec{}, fmt.Errorf("invalid loss value for %s: %w", description, err)
 		}
 

--- a/usecase/build_commit_reputer_payload_test.go
+++ b/usecase/build_commit_reputer_payload_test.go
@@ -112,7 +112,7 @@ func TestComputeLossBundle(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockAdapter := ReturnBasicMockAlloraAdapter()
 			tt.mockSetup(mockAdapter)
-			tt.reputerConfig.ReputerEntrypoint = mockAdapter
+			tt.reputerConfig.GroundTruthEntrypoint = mockAdapter
 
 			suite := &UseCaseSuite{}
 			result, err := suite.ComputeLossBundle(tt.sourceTruth, tt.valueBundle, tt.reputerConfig)

--- a/usecase/build_commit_reputer_payload_test.go
+++ b/usecase/build_commit_reputer_payload_test.go
@@ -12,6 +12,16 @@ import (
 )
 
 func TestComputeLossBundle(t *testing.T) {
+	reputerOptions := map[string]string{
+		"method": "sqe",
+	}
+	reputerConfig := lib.ReputerConfig{
+		LossFunctionParameters: lib.LossFunctionParameters{
+			LossMethodOptions: reputerOptions,
+			IsNeverNegative:   &[]bool{false}[0],
+		},
+	}
+
 	tests := []struct {
 		name                string
 		sourceTruth         string
@@ -41,7 +51,7 @@ func TestComputeLossBundle(t *testing.T) {
 					},
 				}
 			}(),
-			reputerConfig: lib.ReputerConfig{AllowsNegativeValue: true},
+			reputerConfig: reputerConfig,
 			expectedLossStrings: map[string]string{
 				"CombinedValue":    "0.25",
 				"NaiveValue":       "1.00",
@@ -49,10 +59,11 @@ func TestComputeLossBundle(t *testing.T) {
 				"ForecasterValues": "0.04",
 			},
 			mockSetup: func(m *MockAlloraAdapter) {
-				m.On("LossFunction", "10.0", "9.5").Return("0.25", nil)
-				m.On("LossFunction", "10.0", "9.0").Return("1.00", nil)
-				m.On("LossFunction", "10.0", "9.7").Return("0.09", nil)
-				m.On("LossFunction", "10.0", "9.8").Return("0.04", nil)
+				m.On("LossFunction", mock.AnythingOfType("lib.ReputerConfig"), "10.0", "9.5", reputerOptions).Return("0.25", nil)
+				m.On("LossFunction", mock.AnythingOfType("lib.ReputerConfig"), "10.0", "9.0", reputerOptions).Return("1.00", nil)
+				m.On("LossFunction", mock.AnythingOfType("lib.ReputerConfig"), "10.0", "9.7", reputerOptions).Return("0.09", nil)
+				m.On("LossFunction", mock.AnythingOfType("lib.ReputerConfig"), "10.0", "9.8", reputerOptions).Return("0.04", nil)
+				// m.On("IsLossFunctionNeverNegative", mock.AnythingOfType("lib.ReputerConfig"), mock.AnythingOfType("string")).Return(true, nil)
 			},
 			expectError: false,
 		},
@@ -65,9 +76,9 @@ func TestComputeLossBundle(t *testing.T) {
 					CombinedValue: combined,
 				}
 			}(),
-			reputerConfig: lib.ReputerConfig{AllowsNegativeValue: true},
+			reputerConfig: reputerConfig,
 			mockSetup: func(m *MockAlloraAdapter) {
-				m.On("LossFunction", mock.Anything, mock.Anything).Return("", errors.New("loss function error"))
+				m.On("LossFunction", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", errors.New("loss function error"))
 			},
 			expectError:   true,
 			errorContains: "error computing loss for combined value",
@@ -81,9 +92,9 @@ func TestComputeLossBundle(t *testing.T) {
 					CombinedValue: combined,
 				}
 			}(),
-			reputerConfig: lib.ReputerConfig{AllowsNegativeValue: true},
+			reputerConfig: reputerConfig,
 			mockSetup: func(m *MockAlloraAdapter) {
-				m.On("LossFunction", mock.Anything, mock.Anything).Return("invalid", nil)
+				m.On("LossFunction", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("invalid", nil)
 			},
 			expectError:   true,
 			errorContains: "error parsing loss",
@@ -92,7 +103,7 @@ func TestComputeLossBundle(t *testing.T) {
 			name:          "Nil ValueBundle",
 			sourceTruth:   "10.0",
 			valueBundle:   nil,
-			reputerConfig: lib.ReputerConfig{AllowsNegativeValue: true},
+			reputerConfig: reputerConfig,
 			mockSetup:     func(m *MockAlloraAdapter) {},
 			expectError:   true,
 			errorContains: "nil ValueBundle",
@@ -101,7 +112,7 @@ func TestComputeLossBundle(t *testing.T) {
 			name:          "Empty ValueBundle",
 			sourceTruth:   "10.0",
 			valueBundle:   &emissionstypes.ValueBundle{},
-			reputerConfig: lib.ReputerConfig{AllowsNegativeValue: true},
+			reputerConfig: reputerConfig,
 			mockSetup:     func(m *MockAlloraAdapter) {},
 			expectError:   true,
 			errorContains: "empty ValueBundle",
@@ -113,6 +124,7 @@ func TestComputeLossBundle(t *testing.T) {
 			mockAdapter := ReturnBasicMockAlloraAdapter()
 			tt.mockSetup(mockAdapter)
 			tt.reputerConfig.GroundTruthEntrypoint = mockAdapter
+			tt.reputerConfig.LossFunctionEntrypoint = mockAdapter
 
 			suite := &UseCaseSuite{}
 			result, err := suite.ComputeLossBundle(tt.sourceTruth, tt.valueBundle, tt.reputerConfig)

--- a/usecase/build_commit_worker_payload.go
+++ b/usecase/build_commit_worker_payload.go
@@ -116,13 +116,6 @@ func (suite *UseCaseSuite) BuildWorkerPayload(workerResponse lib.WorkerResponse,
 				log.Error().Err(err).Msg("Error converting forecasterValue to Dec")
 				return emissionstypes.InferenceForecastBundle{}, err
 			}
-			if !workerResponse.AllowsNegativeValue {
-				decVal, err = alloraMath.Log10(decVal)
-				if err != nil {
-					log.Error().Err(err).Msg("Error Log10 forecasterElements")
-					return emissionstypes.InferenceForecastBundle{}, err
-				}
-			}
 			forecasterElements = append(forecasterElements, &emissionstypes.ForecastElement{
 				Inferer: val.Worker,
 				Value:   decVal,

--- a/usecase/build_commit_worker_payload_test.go
+++ b/usecase/build_commit_worker_payload_test.go
@@ -1,0 +1,85 @@
+package usecase
+
+// import (
+// 	"allora_offchain_node/lib"
+// 	"testing"
+
+// 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
+// 	"github.com/stretchr/testify/assert"
+// 	"github.com/stretchr/testify/mock"
+// )
+
+// func (suite *UseCaseSuite) SetupTest() {
+// 	// Any setup needed for each test
+// }
+
+// func TestComputeWorkerBundle(t *testing.T) {
+// 	workerOptions := map[string]string{
+// 		"InferenceEndpoint": "http://source:8000/inference/{Token}",
+// 		"Token":             "ETH",
+// 	}
+
+// 	tests := []struct {
+// 		name             string
+// 		workerConfig     lib.WorkerConfig
+// 		mockSetup        func(*MockAlloraAdapter)
+// 		expectedResponse lib.WorkerResponse
+// 		expectError      bool
+// 		errorContains    string
+// 	}{
+// 		{
+// 			name: "Happy path - valid prediction",
+// 			workerConfig: lib.WorkerConfig{
+// 				TopicId:                 emissionstypes.TopicId(1),
+// 				InferenceEntrypointName: "api-worker-reputer",
+// 				ForecastEntrypointName:  "api-worker-reputer",
+// 				InferenceEntrypoint:     nil, // Will be set in the test
+// 				ForecastEntrypoint:      nil, // Will be set in the test
+// 				Parameters:              workerOptions,
+// 				LoopSeconds:             10,
+// 			},
+// 			mockSetup: func(m *MockAlloraAdapter) {
+// 				m.On("CalcInfer", mock.AnythingOfType("lib.WorkerConfig"), workerOptions).Return("9.5", nil)
+// 				m.On("Forecast", mock.AnythingOfType("lib.WorkerConfig"), workerOptions).Return([]lib.NodeValue{{Value: "9.7", Woker: 1234567890}}, nil)
+// 			},
+// 			expectedResponse: lib.WorkerResponse{
+// 				InfererValue:     "9.5",
+// 				ForecasterValues: []lib.NodeValue{{Value: "9.7", Worker: "worker1"}},
+// 			},
+// 			expectError: false,
+// 		},
+// 		// Add more test cases here
+// 	}
+
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			mockAdapter := NewMockAlloraAdapter(t)
+// 			tt.mockSetup(mockAdapter)
+// 			tt.workerConfig.InferenceEntrypoint = mockAdapter
+// 			tt.workerConfig.ForecastEntrypoint = mockAdapter
+
+// 			response, err := suite.CalcInference(tt.workerConfig)
+
+// 			if tt.expectError {
+// 				assert.Error(t, err)
+// 				assert.Contains(t, err.Error(), tt.errorContains)
+// 			} else {
+// 				assert.NoError(t, err)
+// 				assert.Equal(t, tt.expectedResponse.InfererValue, response.InfererValue)
+// 				assert.Equal(t, tt.expectedResponse.ForecasterValues, response.ForecasterValues)
+// 			}
+
+// 			mockAdapter.AssertExpectations(t)
+// 		})
+// 	}
+// }
+
+// func TestSignWorkerValueBundle(t *testing.T) {
+// 	// Implement test for SignWorkerValueBundle
+// }
+
+// func TestBuildCommitWorkerPayload(t *testing.T) {
+// 	// Implement test for BuildCommitWorkerPayload
+// }
+
+// // Add more test functions as needed

--- a/usecase/mock_allora_adapter_test.go
+++ b/usecase/mock_allora_adapter_test.go
@@ -25,7 +25,7 @@ func (m *MockAlloraAdapter) CalcForecast(config lib.WorkerConfig, timestamp int6
 	return args.Get(0).([]lib.NodeValue), args.Error(1)
 }
 
-func (m *MockAlloraAdapter) SourceTruth(config lib.ReputerConfig, timestamp int64) (lib.Truth, error) {
+func (m *MockAlloraAdapter) GroundTruth(config lib.ReputerConfig, timestamp int64) (lib.Truth, error) {
 	args := m.Called(config, timestamp)
 	return args.Get(0).(lib.Truth), args.Error(1)
 }
@@ -45,7 +45,7 @@ func (m *MockAlloraAdapter) CanForecast() bool {
 	return args.Bool(0)
 }
 
-func (m *MockAlloraAdapter) CanSourceTruthAndComputeLoss() bool {
+func (m *MockAlloraAdapter) CanSourceGroundTruthAndComputeLoss() bool {
 	args := m.Called()
 	return args.Bool(0)
 }

--- a/usecase/mock_allora_adapter_test.go
+++ b/usecase/mock_allora_adapter_test.go
@@ -30,8 +30,9 @@ func (m *MockAlloraAdapter) GroundTruth(config lib.ReputerConfig, timestamp int6
 	return args.Get(0).(lib.Truth), args.Error(1)
 }
 
-func (m *MockAlloraAdapter) LossFunction(sourceTruth string, inferenceValue string) (string, error) {
-	args := m.Called(sourceTruth, inferenceValue)
+// Update LossFunction to match the new signature
+func (m *MockAlloraAdapter) LossFunction(node lib.ReputerConfig, sourceTruth string, inferenceValue string, options map[string]string) (string, error) {
+	args := m.Called(node, sourceTruth, inferenceValue, options)
 	return args.String(0), args.Error(1)
 }
 
@@ -50,8 +51,25 @@ func (m *MockAlloraAdapter) CanSourceGroundTruthAndComputeLoss() bool {
 	return args.Bool(0)
 }
 
+// Add the new IsLossFunctionNeverNegative method
+func (m *MockAlloraAdapter) IsLossFunctionNeverNegative(node lib.ReputerConfig, options map[string]string) (bool, error) {
+	args := m.Called(node, options)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockAlloraAdapter) NewTestReputerConfig() lib.ReputerConfig {
+	return lib.ReputerConfig{
+		LossFunctionParameters: lib.LossFunctionParameters{
+			LossMethodOptions: map[string]string{"loss_method": "mse"},
+		},
+		LossFunctionEntrypoint: m,
+	}
+}
+
 func NewMockAlloraAdapter() *MockAlloraAdapter {
-	return &MockAlloraAdapter{}
+	m := &MockAlloraAdapter{}
+
+	return m
 }
 
 func ReturnBasicMockAlloraAdapter() *MockAlloraAdapter {

--- a/usecase/mock_allora_adapter_test.go
+++ b/usecase/mock_allora_adapter_test.go
@@ -57,15 +57,6 @@ func (m *MockAlloraAdapter) IsLossFunctionNeverNegative(node lib.ReputerConfig, 
 	return args.Bool(0), args.Error(1)
 }
 
-func (m *MockAlloraAdapter) NewTestReputerConfig() lib.ReputerConfig {
-	return lib.ReputerConfig{
-		LossFunctionParameters: lib.LossFunctionParameters{
-			LossMethodOptions: map[string]string{"loss_method": "mse"},
-		},
-		LossFunctionEntrypoint: m,
-	}
-}
-
 func NewMockAlloraAdapter() *MockAlloraAdapter {
 	m := &MockAlloraAdapter{}
 

--- a/usecase/utils.go
+++ b/usecase/utils.go
@@ -1,28 +1,13 @@
 package usecase
 
 import (
-	"errors"
 	"time"
 
-	alloraMath "github.com/allora-network/allora-chain/math"
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 )
 
 func (suite *UseCaseSuite) Wait(seconds int64) {
 	time.Sleep(time.Duration(seconds) * time.Second)
-}
-
-// Validations for Dec values
-func ValidateDec(value alloraMath.Dec) error {
-	if value.IsNaN() {
-		return errors.New("value cannot be NaN")
-	}
-
-	if !value.IsFinite() {
-		return errors.New("value must be finite")
-	}
-
-	return nil
 }
 
 func IsEmpty(vb emissionstypes.ValueBundle) bool {
@@ -36,5 +21,6 @@ func IsEmpty(vb emissionstypes.ValueBundle) bool {
 		len(vb.OneOutInfererValues) == 0 &&
 		len(vb.OneOutForecasterValues) == 0 &&
 		len(vb.OneInForecasterValues) == 0 &&
+		len(vb.OneOutInfererForecasterValues) == 0 &&
 		len(vb.ExtraData) == 0
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

* Adds Loss Function implementation into the Extension Framework
* Defines two endpoints for loss functions: calculation and definition of whether function is never negative (applying log on that case), built into the Adapter definition.
* Reformulates configuration
* Naming: uses "Ground Truth" instead of "Source Truth" as unified nomenclature (and typical in ML). Ofc "ground truth" needs to be "sourced" as the name of the action - in case that could cause confusion.
* Updated README
* Use chain validation where appropriate
* Removal of reputer's AllowsNegativeValue, changed for the Loss library
* Removal of reputer's AllowsNegativeValue, this will be implemented in forecaster side, no `log()` applied

## Link(s) to Ticket(s) or Issue(s) resolved by this PR
PROTO-2496

## Are these changes tested and documented?

- [X] If tested, please describe how. If not, why tests are not needed.
Tested manually against current testnet against Allora Loss Function library container and a coin-prediction-reputer.

- [X] If documented, please describe where. If not, describe why docs are not needed. 
Documented in README, then changes will need to be reflected in Allora Docs, reputer sections.

- [x] Added to `Unreleased` section of `CHANGELOG.md`?


