### PR TITLE
Better error handling and msg if waiting for block (EOF)

### DIFF
--- a/lib/repo_tx_utils.go
+++ b/lib/repo_tx_utils.go
@@ -11,11 +11,15 @@ import (
 	"github.com/ignite/cli/v28/ignite/pkg/cosmosclient"
 )
 
+const ERROR_MESSAGE_EMA_ALREADY_SENT = "cannot update EMA"
+const ERROR_MESSAGE_TX_INCLUDED_IN_BLOCK = "waiting for next block"
+
 // SendDataWithRetry attempts to send data with a uniform backoff strategy for retries.
 // uniform backoff is preferred to avoid exiting the open submission windows
 func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg, successMsg string) (*cosmosclient.Response, error) {
 	var txResp *cosmosclient.Response
 	var err error
+	var hadEOFTxError bool
 	for retryCount := int64(0); retryCount <= node.Wallet.MaxRetries; retryCount++ {
 		txResponse, err := node.Chain.Client.BroadcastTx(ctx, node.Chain.Account, req)
 		txResp = &txResponse
@@ -23,9 +27,20 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 			log.Debug().Str("msg", successMsg).Str("txHash", txResp.TxHash).Msg("Success")
 			return txResp, nil
 		}
-		if strings.Contains(err.Error(), "cannot update EMA") {
-			log.Error().Err(err).Str("msg", successMsg).Msg("Already sent data for this epoch, no retry")
-			return nil, err
+		if strings.Contains(err.Error(), ERROR_MESSAGE_TX_INCLUDED_IN_BLOCK) {
+			if !hadEOFTxError {
+				hadEOFTxError = true
+				log.Warn().Err(err).Str("msg", successMsg).Msg("Tx sent, waiting for tx to be included in a block, retry")
+			}
+		}
+		if strings.Contains(err.Error(), ERROR_MESSAGE_EMA_ALREADY_SENT) {
+			if hadEOFTxError {
+				log.Info().Str("msg", successMsg).Msg("Confirmed previously sent tx accepted")
+				return nil, err
+			} else {
+				log.Info().Err(err).Str("msg", successMsg).Msg("Already sent data for this epoch, no retry")
+				return nil, err
+			}
 		}
 		// Log the error for each retry.
 		log.Error().Err(err).Str("msg", successMsg).Msgf("Failed, retrying... (Retry %d/%d)", retryCount, node.Wallet.MaxRetries)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

Better error handliing and msg in case of transactions whose result is not known due to connectivity lost while waiting for next block, so not confirmed whether tx was successful.

Use a boolean to handle such cases specifically, to improve ux.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR
PROTO-2561 

## Are these changes tested and documented?

- [ ] If tested, please describe how. If not, why tests are not needed. -- not tested yet, though it is a trivial change.
- [X] If documented, please describe where. If not, describe why docs are not needed. -- trivial change, not needed, though if the error messages are documented in detail, then it should be.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?


