### PR TITLE
Feemarket dynamic prices as a subroutine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#89](https://github.com/allora-network/allora-offchain-node/pull/89) Added linter
 * [#92](https://github.com/allora-network/allora-offchain-node/pull/92) Context handling
 * [#91](https://github.com/allora-network/allora-offchain-node/pull/91) Add Feemarket support
+* [#94](https://github.com/allora-network/allora-offchain-node/pull/94) Gas price update interval
 
 ### Removed
 

--- a/config.example.json
+++ b/config.example.json
@@ -6,6 +6,7 @@
       "gas": "auto",
       "gasAdjustment": 1.2,
       "gasPrices": "auto",
+      "gasPriceUpdateInterval": 60,
       "maxFees": 500000,
       "nodeRpc": "https://allora-rpc.testnet.allora.network",
       "maxRetries": 5,

--- a/gas_and_fees.md
+++ b/gas_and_fees.md
@@ -14,4 +14,5 @@ Allora Network implements the [Feemarket](https://github.com/skip-mev/feemarket)
 - `gas` (string): can be set to `auto` or a specific gas value. If set to `auto`, the node will automatically calculate the gas limit based on the estimated gas used by the transactions. Recommended: `auto`.
 - `gasAdjustment` (float): is used to adjust the gas limit. Recommended: `1.0-1.2`.
 - `gasPrices` (string): can be set to `auto` or a specific gas price. If set to `auto`, the node will automatically calculate the gas price based on chain's feemarket-based gas prices. This is the recommended setting, since feemarket introduces variability in the gas price in the chain. Recommended: `auto`.
+- `gasPriceUpdateInterval` (int): is the interval in seconds at which the node will update the gas price from the network. This is only relevant when `gasPrices` is set to `auto`. Recommended: `60`.
 - `maxFees` (float): set the max fees that can be paid for a transaction. They are expressed numerically in `uallo`. It is recommended to adjust this value based on experience to optimize results, although a conservative value of `500000` could be a good starting point.

--- a/lib/domain_config.go
+++ b/lib/domain_config.go
@@ -14,8 +14,10 @@ import (
 const (
 	WindowCorrectionFactorSuggestedMin = 0.5
 	BlockDurationEstimatedMin          = 1.0
+	GasPriceUpdateIntervalMin          = 5
 	RetryDelayMin                      = 1
 	AccountSequenceRetryDelayMin       = 1
+	AutoGasPrices                      = "auto"
 )
 
 // Properties manually provided by the user as part of UserConfig
@@ -27,6 +29,7 @@ type WalletConfig struct {
 	Gas                       string  // gas to use for the allora client
 	GasAdjustment             float64 // gas adjustment to use for the allora client
 	GasPrices                 string  // gas prices to use for the allora client - "auto" for no fees
+	GasPriceUpdateInterval    int64   // number of seconds to wait between updates to the gas price
 	MaxFees                   uint64  // max gas to use for the allora client
 	NodeRpc                   string  // rpc node for allora chain
 	MaxRetries                int64   // retry to get data from chain up to this many times per query or tx
@@ -165,6 +168,9 @@ func (c *UserConfig) ValidateWalletConfig() error {
 	}
 	if c.Wallet.AccountSequenceRetryDelay < AccountSequenceRetryDelayMin {
 		return fmt.Errorf("account sequence retry delay lower than the minimum: %d < %d", c.Wallet.AccountSequenceRetryDelay, AccountSequenceRetryDelayMin)
+	}
+	if c.Wallet.GasPrices == AutoGasPrices && c.Wallet.GasPriceUpdateInterval < GasPriceUpdateIntervalMin {
+		return fmt.Errorf("gas price update interval (in 'auto' mode)lower than the minimum: %d < %d", c.Wallet.GasPriceUpdateInterval, GasPriceUpdateIntervalMin)
 	}
 
 	return nil

--- a/lib/repo_query_fee.go
+++ b/lib/repo_query_fee.go
@@ -22,13 +22,12 @@ func (node *NodeConfig) UpdateGasPriceRoutine(ctx context.Context) {
 			log.Info().Msg("Updating fee price routine: terminating.")
 			return
 		default:
-			var err error
 			price, err := node.GetBaseFee(ctx)
 			if err != nil {
 				log.Error().Err(err).Msg("Error updating gas prices")
 			}
-			gasPrice = price
-			log.Debug().Float64("gasPrice", gasPrice).Msg("Updating fee price routine: updating value.")
+			SetGasPrice(price)
+			log.Debug().Float64("gasPrice", GetGasPrice()).Msg("Updating fee price routine: updating value.")
 			time.Sleep(time.Duration(node.Wallet.GasPriceUpdateInterval) * time.Second)
 		}
 	}

--- a/lib/repo_query_fee.go
+++ b/lib/repo_query_fee.go
@@ -4,11 +4,45 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/rs/zerolog/log"
 	feemarkettypes "github.com/skip-mev/feemarket/x/feemarket/types"
 )
+
+// Keeps track of the current gas price
+var gasPrice float64 = 0
+
+// UpdateGasPriceRoutine continuously updates the gas price at a specified interval
+func (node *NodeConfig) UpdateGasPriceRoutine(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info().Msg("Updating fee price routine: terminating.")
+			return
+		default:
+			var err error
+			price, err := node.GetBaseFee(ctx)
+			if err != nil {
+				log.Error().Err(err).Msg("Error updating gas prices")
+			}
+			gasPrice = price
+			log.Debug().Float64("gasPrice", gasPrice).Msg("Updating fee price routine: updating value.")
+			time.Sleep(time.Duration(node.Wallet.GasPriceUpdateInterval) * time.Second)
+		}
+	}
+}
+
+// GetGasPrice returns the current gas price
+func GetGasPrice() float64 {
+	return gasPrice
+}
+
+// SetGasPrice sets the current gas price
+func SetGasPrice(price float64) {
+	gasPrice = price
+}
 
 // GetBaseFee queries the current base fee from the feemarket module
 func (node *NodeConfig) GetBaseFee(ctx context.Context) (float64, error) {

--- a/usecase/spawn_actor_processes.go
+++ b/usecase/spawn_actor_processes.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"math"
+	"strconv"
 	"sync"
 	"time"
 
@@ -44,8 +45,24 @@ type ActorProcessParams[T lib.TopicActor] struct {
 	ActorType string
 }
 
+// Spawns the actor processes and any associated non-essential routines
 func (suite *UseCaseSuite) Spawn(ctx context.Context) {
+	if suite.Node.Wallet.GasPrices == lib.AutoGasPrices {
+		log.Info().Msg("auto gas prices. Updating fee price routine: starting.")
+		go suite.Node.UpdateGasPriceRoutine(ctx)
+	} else {
+		price, err := strconv.ParseFloat(suite.Node.Wallet.GasPrices, 64)
+		if err != nil {
+			log.Error().Err(err).Msg("Invalid gas prices format")
+			return
+		} else {
+			log.Debug().Float64("gasPrice", price).Msg("Setting gas prices manually")
+			lib.SetGasPrice(price)
+		}
+	}
+
 	var wg sync.WaitGroup
+	essentialDone := make(chan struct{}) // Channel for essential routines to signal when they are done
 
 	// Run worker process per topic
 	alreadyStartedWorkerForTopic := make(map[emissionstypes.TopicId]bool)
@@ -60,6 +77,7 @@ func (suite *UseCaseSuite) Spawn(ctx context.Context) {
 		go func(worker lib.WorkerConfig) {
 			defer wg.Done()
 			suite.runWorkerProcess(ctx, worker)
+			log.Error().Uint64("topicId", worker.TopicId).Msg("Worker process finished")
 		}(worker)
 	}
 
@@ -76,11 +94,17 @@ func (suite *UseCaseSuite) Spawn(ctx context.Context) {
 		go func(reputer lib.ReputerConfig) {
 			defer wg.Done()
 			suite.runReputerProcess(ctx, reputer)
+			log.Error().Uint64("topicId", reputer.TopicId).Msg("Reputer process finished")
 		}(reputer)
 	}
 
-	// Wait for all goroutines to finish
-	wg.Wait()
+	// Wait for all essential routines to finish
+	go func() {
+		wg.Wait()
+		close(essentialDone)
+	}()
+
+	<-essentialDone // Block until all essential routines are done
 }
 
 // Attempts to build and commit a worker payload for a given nonce

--- a/usecase/spawn_actor_processes.go
+++ b/usecase/spawn_actor_processes.go
@@ -49,6 +49,13 @@ type ActorProcessParams[T lib.TopicActor] struct {
 func (suite *UseCaseSuite) Spawn(ctx context.Context) {
 	if suite.Node.Wallet.GasPrices == lib.AutoGasPrices {
 		log.Info().Msg("auto gas prices. Updating fee price routine: starting.")
+		price, err := suite.Node.GetBaseFee(ctx)
+		if err != nil {
+			log.Error().Err(err).Msg("Error updating gas prices in auto mode - RPC availability issue?")
+			return
+		}
+		lib.SetGasPrice(price)
+		// After intialization, start auto-update routine
 		go suite.Node.UpdateGasPriceRoutine(ctx)
 	} else {
 		price, err := strconv.ParseFloat(suite.Node.Wallet.GasPrices, 64)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
Converting the current per-actor pre-tx feemarket gas price reading into a non-essential subroutine to periodically run fee readings and store that in a global var which is read by processes (1 writer, N readers).

* Removes a query at the sensitive time of tx submission, making it lighter at the time where it is more sensitive for the client.
* Value is shared by all actor processes instead of pre-tx calls, reducing overall number of calls.
* Routine is nonessential, ie. if other actor routines end, the whole process will end instead of leaving the routine hanging.

New setting to control periodic interval to update fees from network `gasPriceUpdateInterval`.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. -- tested against local v0.7.0 with feemarket
- [x] If documented, please describe where. If not, describe why docs are not needed.  -- added in gas_and_fees
- [x] Added to `Unreleased` section of `CHANGELOG.md`?

