### PR TITLE
Use of RPCManager with auto switching over node configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#104](https://github.com/allora-network/allora-offchain-node/pull/104) Customize rpc client configurations
 * [#105](https://github.com/allora-network/allora-offchain-node/pull/105) Make HTTP timeout configurable
 * [#106](https://github.com/allora-network/allora-offchain-node/pull/106) Improve log context by adding topic id and actor type to logger
+* [#98](https://github.com/allora-network/allora-offchain-node/pull/98) RPC nodes as an array, with rpc-looping management
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ The node will use the following timeouts:
 * `timeoutRPCSecondsRegistration`: Timeout for whole RPC registration process in seconds, including retries.
 * `timeoutHTTPConnection`: Timeout for HTTP connection (underlying to the RPC client) in seconds.
 
+### RPC nodes
+
+From v0.7.1, the RPC nodes to connect to are configured as an array `nodeRpcs` in the config.json file, instead of a single string.
+The offchain node will try to connect to the RPC nodes in order of appearance in the array  .
+If the node is unable to connect to an RPC node, or the node has some particular type of error(e.g. a full mempool, or a `429 Too Many Requests` error), it will switch to the next one in the array.
+If the node has tried all the RPC nodes in the array, and there was an error, it will log an error for that submission and will not try to submit that payload again.
+
 ### Error handling
 
 Error handling is done differently for different types of errors.

--- a/config.example.json
+++ b/config.example.json
@@ -7,8 +7,8 @@
       "gasAdjustment": 1.2,
       "gasPrices": "auto",
       "gasPriceUpdateInterval": 60,
-      "maxFees": "500000",
-      "nodeRpc": "https://allora-rpc.testnet.allora.network",
+      "maxFees": 500000,
+      "nodeRpcs": ["https://allora-rpc.testnet.allora.network"],
       "maxRetries": 5,
       "retryDelay": 3,
       "accountSequenceRetryDelay": 5,
@@ -35,7 +35,7 @@
         "topicId": 1,
         "groundTruthEntrypointName": "apiAdapter",
         "lossFunctionEntrypointName": "apiAdapter",
-        "minStake": "100000000",
+        "minStake": 100000000,
         "groundTruthParameters": {
           "GroundTruthEndpoint": "http://localhost:8888/gt/{Token}/{BlockHeight}",
           "Token": "ETHUSD"

--- a/lib/domain_config.go
+++ b/lib/domain_config.go
@@ -118,6 +118,7 @@ type UserConfig struct {
 }
 
 type NodeConfig struct {
+	RPC     string
 	Chain   ChainConfig
 	Wallet  WalletConfig
 	Worker  []WorkerConfig
@@ -222,8 +223,15 @@ func (c *UserConfig) ValidateWalletConfig() error {
 }
 
 func (reputerConfig *ReputerConfig) ValidateReputerConfig() error {
-	if reputerConfig.GroundTruthEntrypoint != nil && !reputerConfig.GroundTruthEntrypoint.CanSourceGroundTruthAndComputeLoss() {
-		return errors.New("invalid loss entrypoint")
+	if reputerConfig.GroundTruthEntrypointName == "" ||
+		reputerConfig.GroundTruthEntrypoint == nil ||
+		(reputerConfig.GroundTruthEntrypoint != nil &&
+			!reputerConfig.GroundTruthEntrypoint.CanSourceGroundTruthAndComputeLoss()) {
+		return errors.New("invalid ground truth entrypoint")
+	}
+	if reputerConfig.LossFunctionEntrypointName == "" ||
+		reputerConfig.LossFunctionEntrypoint == nil {
+		return errors.New("invalid loss function entrypoint")
 	}
 	return nil
 }

--- a/lib/domain_config.go
+++ b/lib/domain_config.go
@@ -42,7 +42,7 @@ type WalletConfig struct {
 	GasPrices                     string                  // gas prices to use for the allora client - "auto" for auto-calculated fees
 	GasPriceUpdateInterval        int64                   // number of seconds to wait between updates to the gas price
 	MaxFees                       FlexibleCosmosIntAmount // max fees to pay for a single transaction (as string or number)
-	NodeRpc                       string                  // rpc node for allora chain
+	NodeRPCs                      []string                // rpc nodes for allora chain
 	MaxRetries                    int64                   // retry to get data from chain up to this many times per query or tx
 	RetryDelay                    int64                   // number of seconds to wait between retries (general case)
 	AccountSequenceRetryDelay     int64                   // number of seconds to wait between retries in case of account sequence error

--- a/lib/errors.go
+++ b/lib/errors.go
@@ -1,0 +1,220 @@
+package lib
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+
+	errorsmod "cosmossdk.io/errors"
+	emissions "github.com/allora-network/allora-chain/x/emissions/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/rs/zerolog/log"
+	feemarkettypes "github.com/skip-mev/feemarket/x/feemarket/types"
+)
+
+// Error codes for the module
+const ERROR_CODESPACE = "allora-offchain-lib"
+
+var (
+	ErrTooManyRequests  = errorsmod.Register(ERROR_CODESPACE, 1, "too many requests")
+	ErrNotEnoughBalance = errorsmod.Register(ERROR_CODESPACE, 2, "not enough balance")
+	ErrNotRegistered    = errorsmod.Register(ERROR_CODESPACE, 3, "not registered")
+	ErrStakeBelowMin    = errorsmod.Register(ERROR_CODESPACE, 4, "stake below minimum")
+)
+
+const ERROR_MESSAGE_ABCI_ERROR_CODE_MARKER = "error code:"
+const ERROR_MESSAGE_DATA_ALREADY_SUBMITTED = "already submitted"
+const ERROR_MESSAGE_CANNOT_UPDATE_EMA = "cannot update EMA"
+const ERROR_MESSAGE_WAITING_FOR_NEXT_BLOCK = "waiting for next block" // This means tx is accepted in mempool but not yet included in a block
+const ERROR_MESSAGE_ACCOUNT_SEQUENCE_MISMATCH = "account sequence mismatch"
+const ERROR_MESSAGE_TIMEOUT_HEIGHT = "timeout height"
+const ERROR_MESSAGE_NOT_PERMITTED_TO_SUBMIT_PAYLOAD = "not permitted to submit payload"
+const ERROR_MESSAGE_NOT_PERMITTED_TO_ADD_STAKE = "not permitted to add stake"
+
+const EXCESS_CORRECTION_IN_GAS = 20000
+
+// Error processing types
+// - "continue", nil: tx was not successful, but special error type. Handled, ready for retry
+// - "ok", nil: tx was successful, error handled and not re-raised
+// - "error", error: tx failed, with regular error type
+// - "fees": tx failed, because of insufficient fees
+// - "failure": tx failed, and should not be retried anymore
+const ERROR_PROCESSING_CONTINUE = "continue"
+const ERROR_PROCESSING_OK = "ok"
+const ERROR_PROCESSING_FEES = "fees"
+const ERROR_PROCESSING_ERROR = "error"
+const ERROR_PROCESSING_FAILURE = "failure"
+const ERROR_PROCESSING_SWITCHING_NODE = "switch"
+
+// HTTP status codes that trigger node switching
+var HTTP_STATUS_CODES_SWITCHING_NODE = map[int]bool{
+	429: true, // Too Many Requests
+}
+
+// calculateExponentialBackoffDelay returns a duration based on retry count and base delay
+func calculateExponentialBackoffDelaySeconds(baseDelay int64, retryCount int64) int64 {
+	return int64(math.Pow(float64(baseDelay), float64(retryCount)))
+}
+
+// processError handles the error messages.
+func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount int64, node *NodeConfig) (string, error) {
+	if strings.Contains(err.Error(), ERROR_MESSAGE_ABCI_ERROR_CODE_MARKER) {
+		re := regexp.MustCompile(`error code: '(\d+)'`)
+		matches := re.FindStringSubmatch(err.Error())
+		if len(matches) == 2 {
+			errorCode, parseErr := strconv.Atoi(matches[1])
+			if parseErr != nil {
+				log.Error().Err(parseErr).Str("msg", infoMsg).Msg("Failed to parse ABCI error code")
+			} else {
+				switch errorCode {
+				case int(sdkerrors.ErrMempoolIsFull.ABCICode()):
+					log.Warn().
+						Err(err).
+						Str("msg", infoMsg).
+						Msg("Mempool is full, retrying with exponential backoff")
+					delay := calculateExponentialBackoffDelaySeconds(node.Wallet.RetryDelay, retryCount)
+					if DoneOrWait(ctx, delay) {
+						return ERROR_PROCESSING_ERROR, ctx.Err()
+					}
+					return ERROR_PROCESSING_CONTINUE, nil
+				case int(sdkerrors.ErrWrongSequence.ABCICode()), int(sdkerrors.ErrInvalidSequence.ABCICode()):
+					log.Warn().
+						Err(err).
+						Str("msg", infoMsg).
+						Int64("delay", node.Wallet.AccountSequenceRetryDelay).
+						Msg("Account sequence mismatch detected, retrying with fixed delay")
+					// Wait a fixed block-related waiting time
+					if DoneOrWait(ctx, node.Wallet.AccountSequenceRetryDelay) {
+						return ERROR_PROCESSING_ERROR, ctx.Err()
+					}
+					return ERROR_PROCESSING_CONTINUE, nil
+				case int(sdkerrors.ErrInsufficientFee.ABCICode()):
+					log.Info().
+						Err(err).
+						Str("msg", infoMsg).
+						Msg("Insufficient fees")
+					return ERROR_PROCESSING_FEES, nil
+				case int(feemarkettypes.ErrNoFeeCoins.ABCICode()):
+					log.Info().
+						Err(err).
+						Str("msg", infoMsg).
+						Msg("No fee coins")
+					return ERROR_PROCESSING_FEES, nil
+				case int(sdkerrors.ErrTxTooLarge.ABCICode()):
+					return ERROR_PROCESSING_ERROR, errorsmod.Wrapf(err, "tx too large")
+				case int(sdkerrors.ErrTxInMempoolCache.ABCICode()):
+					return ERROR_PROCESSING_ERROR, errorsmod.Wrapf(err, "tx already in mempool cache")
+				case int(sdkerrors.ErrInvalidChainID.ABCICode()):
+					return ERROR_PROCESSING_ERROR, errorsmod.Wrapf(err, "invalid chain-id")
+				case int(sdkerrors.ErrTxTimeoutHeight.ABCICode()):
+					return ERROR_PROCESSING_FAILURE, errorsmod.Wrapf(err, "tx timeout height")
+				case int(emissions.ErrWorkerNonceWindowNotAvailable.ABCICode()):
+					log.Warn().
+						Err(err).
+						Str("msg", infoMsg).
+						Msg("Worker window not available, retrying with exponential backoff")
+					delay := calculateExponentialBackoffDelaySeconds(node.Wallet.RetryDelay, retryCount)
+					if DoneOrWait(ctx, delay) {
+						return ERROR_PROCESSING_ERROR, ctx.Err()
+					}
+					return ERROR_PROCESSING_CONTINUE, nil
+				case int(emissions.ErrReputerNonceWindowNotAvailable.ABCICode()):
+					log.Warn().
+						Err(err).
+						Str("msg", infoMsg).
+						Msg("Reputer window not available, retrying with exponential backoff")
+					delay := calculateExponentialBackoffDelaySeconds(node.Wallet.RetryDelay, retryCount)
+					if DoneOrWait(ctx, delay) {
+						return ERROR_PROCESSING_ERROR, ctx.Err()
+					}
+					return ERROR_PROCESSING_CONTINUE, nil
+				default:
+					log.Info().Int("errorCode", errorCode).Str("msg", infoMsg).Msg("ABCI error, but not special case - regular retry")
+				}
+			}
+		} else {
+			log.Warn().Str("msg", infoMsg).Msg("Unmatched error format, cannot classify as ABCI error")
+		}
+	}
+
+	// Check if error is HTTP status code
+	if statusCode, statusMessage, error := ParseHTTPStatus(err.Error()); error == nil {
+		log.Warn().Int("statusCode", statusCode).Str("statusMessage", statusMessage).Str("msg", infoMsg).Msg("HTTP status code detected")
+		if statusCode, statusMessage, err := ParseHTTPStatus(err.Error()); err == nil {
+			log.Warn().Int("statusCode", statusCode).Str("statusMessage", statusMessage).Str("msg", infoMsg).Msg("HTTP status code detected")
+
+			if HTTP_STATUS_CODES_SWITCHING_NODE[statusCode] {
+				log.Warn().
+					Int("statusCode", statusCode).
+					Str("msg", infoMsg).
+					Msg("HTTP status error code detected, switching to next node")
+				return ERROR_PROCESSING_SWITCHING_NODE, ErrTooManyRequests
+			}
+		}
+	}
+
+	// NOT ABCI error code: keep on checking for specially handled error types
+	if strings.Contains(err.Error(), ERROR_MESSAGE_ACCOUNT_SEQUENCE_MISMATCH) {
+		log.Warn().
+			Err(err).
+			Str("msg", infoMsg).
+			Int64("delay", node.Wallet.AccountSequenceRetryDelay).
+			Msg("Account sequence mismatch detected, re-fetching sequence")
+		if DoneOrWait(ctx, node.Wallet.AccountSequenceRetryDelay) {
+			return ERROR_PROCESSING_ERROR, ctx.Err()
+		}
+		return ERROR_PROCESSING_CONTINUE, nil
+	} else if strings.Contains(err.Error(), ERROR_MESSAGE_WAITING_FOR_NEXT_BLOCK) {
+		log.Warn().Err(err).Str("msg", infoMsg).Msg("Tx accepted in mempool, it will be included in the following block(s) - not retrying")
+		return ERROR_PROCESSING_OK, nil
+	} else if strings.Contains(err.Error(), ERROR_MESSAGE_DATA_ALREADY_SUBMITTED) || strings.Contains(err.Error(), ERROR_MESSAGE_CANNOT_UPDATE_EMA) {
+		log.Warn().Err(err).Str("msg", infoMsg).Msg("Already submitted data for this epoch.")
+		return ERROR_PROCESSING_OK, nil
+	} else if strings.Contains(err.Error(), ERROR_MESSAGE_TIMEOUT_HEIGHT) {
+		log.Warn().Err(err).Str("msg", infoMsg).Msg("Tx failed because of timeout height")
+		return ERROR_PROCESSING_FAILURE, err
+	} else if strings.Contains(err.Error(), ERROR_MESSAGE_NOT_PERMITTED_TO_SUBMIT_PAYLOAD) {
+		log.Warn().Err(err).Str("msg", infoMsg).Msg("Actor is not permitted to submit payload")
+		return ERROR_PROCESSING_FAILURE, err
+	} else if strings.Contains(err.Error(), ERROR_MESSAGE_NOT_PERMITTED_TO_ADD_STAKE) {
+		log.Warn().Err(err).Str("msg", infoMsg).Msg("Actor is not permitted to add stake")
+		return ERROR_PROCESSING_FAILURE, err
+	}
+
+	return ERROR_PROCESSING_ERROR, errorsmod.Wrapf(err, "failed to process error")
+}
+
+// func ProcessErrorQuery(ctx context.Context, err error, infoMsg string, retryCount int64, node *NodeConfig) (string, error) {
+
+// }
+
+// ParseStatus parses a status code and message from a given text string.
+func ParseHTTPStatus(input string) (int, string, error) {
+	// Regular expression to match "Status: <code> <message>" or similar patterns in text
+	re := regexp.MustCompile(`(?i)status:\s*(\d+)\s*([^,]*)`)
+
+	matches := re.FindStringSubmatch(input)
+	if len(matches) < 3 {
+		return 0, "", errors.New("invalid input format")
+	}
+
+	// Parse the status code
+	statusCode, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, "", fmt.Errorf("invalid status code: %v", err)
+	}
+
+	// Get the status message
+	statusMessage := strings.TrimSpace(matches[2])
+
+	return statusCode, statusMessage, nil
+}
+
+// Returns true if the error is a switching-node error
+func IsErrorSwitchingNode(err error) bool {
+	return errors.Is(err, ErrTooManyRequests)
+}

--- a/lib/errors.go
+++ b/lib/errors.go
@@ -106,8 +106,10 @@ func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount, 
 
 // triageABCIErrorCode handles specific ABCI error codes and returns appropriate processing instructions
 func triageABCIErrorCode(ctx context.Context, errorCode int, err error, infoMsg string, retryCount, retryMax int64, node *NodeConfig) (string, error) {
-	switch errorCode {
-	case int(sdkerrors.ErrMempoolIsFull.ABCICode()):
+	// parse error code into int32 for ABCI error code comparison
+	errorCodeInt32 := uint32(errorCode)
+	switch errorCodeInt32 {
+	case sdkerrors.ErrMempoolIsFull.ABCICode():
 		// Exhaust retries before switching to next node
 		if retryCount >= retryMax {
 			log.Info().
@@ -126,7 +128,7 @@ func triageABCIErrorCode(ctx context.Context, errorCode int, err error, infoMsg 
 				Msg("Mempool is full, retrying with exponential backoff")
 			return ErrorProcessingContinue, nil
 		}
-	case int(sdkerrors.ErrWrongSequence.ABCICode()), int(sdkerrors.ErrInvalidSequence.ABCICode()):
+	case sdkerrors.ErrWrongSequence.ABCICode(), sdkerrors.ErrInvalidSequence.ABCICode():
 		log.Warn().
 			Err(err).
 			Str("msg", infoMsg).
@@ -137,27 +139,27 @@ func triageABCIErrorCode(ctx context.Context, errorCode int, err error, infoMsg 
 			return ErrorProcessingError, ctx.Err()
 		}
 		return ErrorProcessingContinue, nil
-	case int(sdkerrors.ErrInsufficientFee.ABCICode()):
+	case sdkerrors.ErrInsufficientFee.ABCICode():
 		log.Info().
 			Err(err).
 			Str("msg", infoMsg).
 			Msg("Insufficient fees")
 		return ErrorProcessingFees, nil
-	case int(feemarkettypes.ErrNoFeeCoins.ABCICode()):
+	case feemarkettypes.ErrNoFeeCoins.ABCICode():
 		log.Info().
 			Err(err).
 			Str("msg", infoMsg).
 			Msg("No fee coins")
 		return ErrorProcessingFees, nil
-	case int(sdkerrors.ErrTxTooLarge.ABCICode()):
+	case sdkerrors.ErrTxTooLarge.ABCICode():
 		return ErrorProcessingError, errorsmod.Wrapf(err, "tx too large")
-	case int(sdkerrors.ErrTxInMempoolCache.ABCICode()):
+	case sdkerrors.ErrTxInMempoolCache.ABCICode():
 		return ErrorProcessingError, errorsmod.Wrapf(err, "tx already in mempool cache")
-	case int(sdkerrors.ErrInvalidChainID.ABCICode()):
+	case sdkerrors.ErrInvalidChainID.ABCICode():
 		return ErrorProcessingError, errorsmod.Wrapf(err, "invalid chain-id")
-	case int(sdkerrors.ErrTxTimeoutHeight.ABCICode()):
+	case sdkerrors.ErrTxTimeoutHeight.ABCICode():
 		return ErrorProcessingFailure, errorsmod.Wrapf(err, "tx timeout height")
-	case int(emissions.ErrWorkerNonceWindowNotAvailable.ABCICode()):
+	case emissions.ErrWorkerNonceWindowNotAvailable.ABCICode():
 		log.Warn().
 			Err(err).
 			Str("msg", infoMsg).
@@ -167,7 +169,7 @@ func triageABCIErrorCode(ctx context.Context, errorCode int, err error, infoMsg 
 			return ErrorProcessingError, ctx.Err()
 		}
 		return ErrorProcessingContinue, nil
-	case int(emissions.ErrReputerNonceWindowNotAvailable.ABCICode()):
+	case emissions.ErrReputerNonceWindowNotAvailable.ABCICode():
 		log.Warn().
 			Err(err).
 			Str("msg", infoMsg).
@@ -178,7 +180,7 @@ func triageABCIErrorCode(ctx context.Context, errorCode int, err error, infoMsg 
 		}
 		return ErrorProcessingContinue, nil
 	default:
-		log.Info().Int("errorCode", errorCode).Str("msg", infoMsg).Msg("ABCI error, but not special case - regular retry")
+		log.Info().Uint32("errorCode", errorCodeInt32).Str("msg", infoMsg).Msg("ABCI error, but not special case - regular retry")
 		return ErrorProcessingError, err
 	}
 }

--- a/lib/errors.go
+++ b/lib/errors.go
@@ -20,7 +20,7 @@ import (
 const ErrorCodespace = "allora-offchain-lib"
 
 var (
-	HTTPError            = errorsmod.Register(ErrorCodespace, 1, "http error")
+	ErrHTTP              = errorsmod.Register(ErrorCodespace, 1, "http error")
 	ErrNotEnoughBalance  = errorsmod.Register(ErrorCodespace, 2, "not enough balance")
 	ErrNotRegistered     = errorsmod.Register(ErrorCodespace, 3, "not registered")
 	ErrStakeBelowMin     = errorsmod.Register(ErrorCodespace, 4, "stake below minimum")
@@ -87,11 +87,13 @@ func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount, 
 		if len(matches) == 2 {
 			errorCode, parseErr := strconv.ParseUint(matches[1], 10, 32)
 			if parseErr != nil {
-				log.Error().Err(parseErr).Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Failed to parse ABCI error code")
-			} else if errorCode > math.MaxUint32 {
-				log.Error().Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Parsed ABCI error code exceeds uint32 bounds")
+				log.Error().Err(parseErr).Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Failed to parse ABCI error code, skipping ABCI error code triage")
 			} else {
-				return triageABCIErrorCode(ctx, uint32(errorCode), err, infoMsg, retryCount, retryMax, node)
+				if errorCode > math.MaxUint32 {
+					log.Error().Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Parsed ABCI error code exceeds uint32 bounds, skipping ABCI error code triage")
+				} else {
+					return triageABCIErrorCode(ctx, uint32(errorCode), err, infoMsg, retryCount, retryMax, node)
+				}
 			}
 		} else {
 			log.Warn().Str("msg", infoMsg).Msg("Unmatched error format, cannot classify as ABCI error")
@@ -248,7 +250,7 @@ func triageHTTPStatusError(err error, node *NodeConfig, infoMsg string) (string,
 				Str("statusMessage", statusMessage).
 				Str("msg", infoMsg).
 				Msg("HTTP status error code detected, switching to next node")
-			return ErrorProcessingSwitchingNode, HTTPError
+			return ErrorProcessingSwitchingNode, ErrHTTP
 		}
 	}
 	return "", nil
@@ -278,7 +280,7 @@ func ParseHTTPStatus(input string) (int, string, error) {
 
 // Returns true if the error is a switching-node error
 func IsErrorSwitchingNode(err error) bool {
-	return errors.Is(err, HTTPError) ||
+	return errors.Is(err, ErrHTTP) ||
 		errors.Is(err, ErrFullMempool) ||
 		errors.Is(err, ErrReadPanic) ||
 		errors.Is(err, ErrConnectionRefused) ||

--- a/lib/errors.go
+++ b/lib/errors.go
@@ -85,11 +85,13 @@ func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount, 
 		re := regexp.MustCompile(`error code: '(\d+)'`)
 		matches := re.FindStringSubmatch(err.Error())
 		if len(matches) == 2 {
-			errorCode, parseErr := strconv.Atoi(matches[1])
+			errorCode, parseErr := strconv.ParseUint(matches[1], 10, 32)
 			if parseErr != nil {
 				log.Error().Err(parseErr).Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Failed to parse ABCI error code")
+			} else if errorCode > math.MaxUint32 {
+				log.Error().Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Parsed ABCI error code exceeds uint32 bounds")
 			} else {
-				return triageABCIErrorCode(ctx, errorCode, err, infoMsg, retryCount, retryMax, node)
+				return triageABCIErrorCode(ctx, uint32(errorCode), err, infoMsg, retryCount, retryMax, node)
 			}
 		} else {
 			log.Warn().Str("msg", infoMsg).Msg("Unmatched error format, cannot classify as ABCI error")
@@ -105,13 +107,8 @@ func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount, 
 }
 
 // triageABCIErrorCode handles specific ABCI error codes and returns appropriate processing instructions
-func triageABCIErrorCode(ctx context.Context, errorCode int, err error, infoMsg string, retryCount, retryMax int64, node *NodeConfig) (string, error) {
-	// parse error code into int32 for ABCI error code comparison
-	if errorCode < 0 || errorCode > math.MaxUint32 {
-		return ErrorProcessingFailure, errorsmod.Wrapf(err, "error code %d out of valid uint32 range", errorCode)
-	}
-	errorCodeInt32 := uint32(errorCode)
-	switch errorCodeInt32 {
+func triageABCIErrorCode(ctx context.Context, errorCode uint32, err error, infoMsg string, retryCount, retryMax int64, node *NodeConfig) (string, error) {
+	switch errorCode {
 	case sdkerrors.ErrMempoolIsFull.ABCICode():
 		// Exhaust retries before switching to next node
 		if retryCount >= retryMax {
@@ -183,7 +180,7 @@ func triageABCIErrorCode(ctx context.Context, errorCode int, err error, infoMsg 
 		}
 		return ErrorProcessingContinue, nil
 	default:
-		log.Info().Uint32("errorCode", errorCodeInt32).Str("msg", infoMsg).Msg("ABCI error, but not special case - regular retry")
+		log.Info().Uint32("errorCode", errorCode).Str("msg", infoMsg).Msg("ABCI error, but not special case - regular retry")
 		return ErrorProcessingError, err
 	}
 }

--- a/lib/errors.go
+++ b/lib/errors.go
@@ -17,25 +17,25 @@ import (
 )
 
 // Error codes for the module
-const ERROR_CODESPACE = "allora-offchain-lib"
+const ErrorCodespace = "allora-offchain-lib"
 
 var (
-	ErrTooManyRequests  = errorsmod.Register(ERROR_CODESPACE, 1, "too many requests")
-	ErrNotEnoughBalance = errorsmod.Register(ERROR_CODESPACE, 2, "not enough balance")
-	ErrNotRegistered    = errorsmod.Register(ERROR_CODESPACE, 3, "not registered")
-	ErrStakeBelowMin    = errorsmod.Register(ERROR_CODESPACE, 4, "stake below minimum")
+	ErrTooManyRequests  = errorsmod.Register(ErrorCodespace, 1, "too many requests")
+	ErrNotEnoughBalance = errorsmod.Register(ErrorCodespace, 2, "not enough balance")
+	ErrNotRegistered    = errorsmod.Register(ErrorCodespace, 3, "not registered")
+	ErrStakeBelowMin    = errorsmod.Register(ErrorCodespace, 4, "stake below minimum")
 )
 
-const ERROR_MESSAGE_ABCI_ERROR_CODE_MARKER = "error code:"
-const ERROR_MESSAGE_DATA_ALREADY_SUBMITTED = "already submitted"
-const ERROR_MESSAGE_CANNOT_UPDATE_EMA = "cannot update EMA"
-const ERROR_MESSAGE_WAITING_FOR_NEXT_BLOCK = "waiting for next block" // This means tx is accepted in mempool but not yet included in a block
-const ERROR_MESSAGE_ACCOUNT_SEQUENCE_MISMATCH = "account sequence mismatch"
-const ERROR_MESSAGE_TIMEOUT_HEIGHT = "timeout height"
-const ERROR_MESSAGE_NOT_PERMITTED_TO_SUBMIT_PAYLOAD = "not permitted to submit payload"
-const ERROR_MESSAGE_NOT_PERMITTED_TO_ADD_STAKE = "not permitted to add stake"
+const ErrorMessageAbciErrorCodeMarker = "error code:"
+const ErrorMessageDataAlreadySubmitted = "already submitted"
+const ErrorMessageCannotUpdateEma = "cannot update EMA"
+const ErrorMessageWaitingForNextBlock = "waiting for next block" // This means tx is accepted in mempool but not yet included in a block
+const ErrorMessageAccountSequenceMismatch = "account sequence mismatch"
+const ErrorMessageTimeoutHeight = "timeout height"
+const ErrorMessageNotPermittedToSubmitPayload = "not permitted to submit payload"
+const ErrorMessageNotPermittedToAddStake = "not permitted to add stake"
 
-const EXCESS_CORRECTION_IN_GAS = 20000
+const ExcessCorrectionInGas = 20000
 
 // Error processing types
 // - "continue", nil: tx was not successful, but special error type. Handled, ready for retry
@@ -43,15 +43,16 @@ const EXCESS_CORRECTION_IN_GAS = 20000
 // - "error", error: tx failed, with regular error type
 // - "fees": tx failed, because of insufficient fees
 // - "failure": tx failed, and should not be retried anymore
-const ERROR_PROCESSING_CONTINUE = "continue"
-const ERROR_PROCESSING_OK = "ok"
-const ERROR_PROCESSING_FEES = "fees"
-const ERROR_PROCESSING_ERROR = "error"
-const ERROR_PROCESSING_FAILURE = "failure"
-const ERROR_PROCESSING_SWITCHING_NODE = "switch"
+// - "switch": tx failed, and should be retried with a different node
+const ErrorProcessingContinue = "continue"
+const ErrorProcessingOk = "ok"
+const ErrorProcessingFees = "fees"
+const ErrorProcessingError = "error"
+const ErrorProcessingFailure = "failure"
+const ErrorProcessingSwitchingNode = "switch"
 
 // HTTP status codes that trigger node switching
-var HTTP_STATUS_CODES_SWITCHING_NODE = map[int]bool{
+var HTTPStatusCodeCodesSwitchingNode = map[int]bool{
 	429: true, // Too Many Requests
 }
 
@@ -62,7 +63,7 @@ func calculateExponentialBackoffDelaySeconds(baseDelay int64, retryCount int64) 
 
 // processError handles the error messages.
 func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount int64, node *NodeConfig) (string, error) {
-	if strings.Contains(err.Error(), ERROR_MESSAGE_ABCI_ERROR_CODE_MARKER) {
+	if strings.Contains(err.Error(), ErrorMessageAbciErrorCodeMarker) {
 		re := regexp.MustCompile(`error code: '(\d+)'`)
 		matches := re.FindStringSubmatch(err.Error())
 		if len(matches) == 2 {
@@ -78,9 +79,9 @@ func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount i
 						Msg("Mempool is full, retrying with exponential backoff")
 					delay := calculateExponentialBackoffDelaySeconds(node.Wallet.RetryDelay, retryCount)
 					if DoneOrWait(ctx, delay) {
-						return ERROR_PROCESSING_ERROR, ctx.Err()
+						return ErrorProcessingError, ctx.Err()
 					}
-					return ERROR_PROCESSING_CONTINUE, nil
+					return ErrorProcessingContinue, nil
 				case int(sdkerrors.ErrWrongSequence.ABCICode()), int(sdkerrors.ErrInvalidSequence.ABCICode()):
 					log.Warn().
 						Err(err).
@@ -89,29 +90,29 @@ func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount i
 						Msg("Account sequence mismatch detected, retrying with fixed delay")
 					// Wait a fixed block-related waiting time
 					if DoneOrWait(ctx, node.Wallet.AccountSequenceRetryDelay) {
-						return ERROR_PROCESSING_ERROR, ctx.Err()
+						return ErrorProcessingError, ctx.Err()
 					}
-					return ERROR_PROCESSING_CONTINUE, nil
+					return ErrorProcessingContinue, nil
 				case int(sdkerrors.ErrInsufficientFee.ABCICode()):
 					log.Info().
 						Err(err).
 						Str("msg", infoMsg).
 						Msg("Insufficient fees")
-					return ERROR_PROCESSING_FEES, nil
+					return ErrorProcessingFees, nil
 				case int(feemarkettypes.ErrNoFeeCoins.ABCICode()):
 					log.Info().
 						Err(err).
 						Str("msg", infoMsg).
 						Msg("No fee coins")
-					return ERROR_PROCESSING_FEES, nil
+					return ErrorProcessingFees, nil
 				case int(sdkerrors.ErrTxTooLarge.ABCICode()):
-					return ERROR_PROCESSING_ERROR, errorsmod.Wrapf(err, "tx too large")
+					return ErrorProcessingError, errorsmod.Wrapf(err, "tx too large")
 				case int(sdkerrors.ErrTxInMempoolCache.ABCICode()):
-					return ERROR_PROCESSING_ERROR, errorsmod.Wrapf(err, "tx already in mempool cache")
+					return ErrorProcessingError, errorsmod.Wrapf(err, "tx already in mempool cache")
 				case int(sdkerrors.ErrInvalidChainID.ABCICode()):
-					return ERROR_PROCESSING_ERROR, errorsmod.Wrapf(err, "invalid chain-id")
+					return ErrorProcessingError, errorsmod.Wrapf(err, "invalid chain-id")
 				case int(sdkerrors.ErrTxTimeoutHeight.ABCICode()):
-					return ERROR_PROCESSING_FAILURE, errorsmod.Wrapf(err, "tx timeout height")
+					return ErrorProcessingFailure, errorsmod.Wrapf(err, "tx timeout height")
 				case int(emissions.ErrWorkerNonceWindowNotAvailable.ABCICode()):
 					log.Warn().
 						Err(err).
@@ -119,9 +120,9 @@ func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount i
 						Msg("Worker window not available, retrying with exponential backoff")
 					delay := calculateExponentialBackoffDelaySeconds(node.Wallet.RetryDelay, retryCount)
 					if DoneOrWait(ctx, delay) {
-						return ERROR_PROCESSING_ERROR, ctx.Err()
+						return ErrorProcessingError, ctx.Err()
 					}
-					return ERROR_PROCESSING_CONTINUE, nil
+					return ErrorProcessingContinue, nil
 				case int(emissions.ErrReputerNonceWindowNotAvailable.ABCICode()):
 					log.Warn().
 						Err(err).
@@ -129,9 +130,9 @@ func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount i
 						Msg("Reputer window not available, retrying with exponential backoff")
 					delay := calculateExponentialBackoffDelaySeconds(node.Wallet.RetryDelay, retryCount)
 					if DoneOrWait(ctx, delay) {
-						return ERROR_PROCESSING_ERROR, ctx.Err()
+						return ErrorProcessingError, ctx.Err()
 					}
-					return ERROR_PROCESSING_CONTINUE, nil
+					return ErrorProcessingContinue, nil
 				default:
 					log.Info().Int("errorCode", errorCode).Str("msg", infoMsg).Msg("ABCI error, but not special case - regular retry")
 				}
@@ -147,45 +148,45 @@ func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount i
 		if statusCode, statusMessage, err := ParseHTTPStatus(err.Error()); err == nil {
 			log.Warn().Int("statusCode", statusCode).Str("statusMessage", statusMessage).Str("msg", infoMsg).Msg("HTTP status code detected")
 
-			if HTTP_STATUS_CODES_SWITCHING_NODE[statusCode] {
+			if HTTPStatusCodeCodesSwitchingNode[statusCode] {
 				log.Warn().
 					Int("statusCode", statusCode).
 					Str("msg", infoMsg).
 					Msg("HTTP status error code detected, switching to next node")
-				return ERROR_PROCESSING_SWITCHING_NODE, ErrTooManyRequests
+				return ErrorProcessingSwitchingNode, ErrTooManyRequests
 			}
 		}
 	}
 
 	// NOT ABCI error code: keep on checking for specially handled error types
-	if strings.Contains(err.Error(), ERROR_MESSAGE_ACCOUNT_SEQUENCE_MISMATCH) {
+	if strings.Contains(err.Error(), ErrorMessageAccountSequenceMismatch) {
 		log.Warn().
 			Err(err).
 			Str("msg", infoMsg).
 			Int64("delay", node.Wallet.AccountSequenceRetryDelay).
 			Msg("Account sequence mismatch detected, re-fetching sequence")
 		if DoneOrWait(ctx, node.Wallet.AccountSequenceRetryDelay) {
-			return ERROR_PROCESSING_ERROR, ctx.Err()
+			return ErrorProcessingError, ctx.Err()
 		}
-		return ERROR_PROCESSING_CONTINUE, nil
-	} else if strings.Contains(err.Error(), ERROR_MESSAGE_WAITING_FOR_NEXT_BLOCK) {
+		return ErrorProcessingContinue, nil
+	} else if strings.Contains(err.Error(), ErrorMessageWaitingForNextBlock) {
 		log.Warn().Err(err).Str("msg", infoMsg).Msg("Tx accepted in mempool, it will be included in the following block(s) - not retrying")
-		return ERROR_PROCESSING_OK, nil
-	} else if strings.Contains(err.Error(), ERROR_MESSAGE_DATA_ALREADY_SUBMITTED) || strings.Contains(err.Error(), ERROR_MESSAGE_CANNOT_UPDATE_EMA) {
+		return ErrorProcessingOk, nil
+	} else if strings.Contains(err.Error(), ErrorMessageDataAlreadySubmitted) || strings.Contains(err.Error(), ErrorMessageCannotUpdateEma) {
 		log.Warn().Err(err).Str("msg", infoMsg).Msg("Already submitted data for this epoch.")
-		return ERROR_PROCESSING_OK, nil
-	} else if strings.Contains(err.Error(), ERROR_MESSAGE_TIMEOUT_HEIGHT) {
+		return ErrorProcessingOk, nil
+	} else if strings.Contains(err.Error(), ErrorMessageTimeoutHeight) {
 		log.Warn().Err(err).Str("msg", infoMsg).Msg("Tx failed because of timeout height")
-		return ERROR_PROCESSING_FAILURE, err
-	} else if strings.Contains(err.Error(), ERROR_MESSAGE_NOT_PERMITTED_TO_SUBMIT_PAYLOAD) {
+		return ErrorProcessingFailure, err
+	} else if strings.Contains(err.Error(), ErrorMessageNotPermittedToSubmitPayload) {
 		log.Warn().Err(err).Str("msg", infoMsg).Msg("Actor is not permitted to submit payload")
-		return ERROR_PROCESSING_FAILURE, err
-	} else if strings.Contains(err.Error(), ERROR_MESSAGE_NOT_PERMITTED_TO_ADD_STAKE) {
+		return ErrorProcessingFailure, err
+	} else if strings.Contains(err.Error(), ErrorMessageNotPermittedToAddStake) {
 		log.Warn().Err(err).Str("msg", infoMsg).Msg("Actor is not permitted to add stake")
-		return ERROR_PROCESSING_FAILURE, err
+		return ErrorProcessingFailure, err
 	}
 
-	return ERROR_PROCESSING_ERROR, errorsmod.Wrapf(err, "failed to process error")
+	return ErrorProcessingError, errorsmod.Wrapf(err, "failed to process error")
 }
 
 // func ProcessErrorQuery(ctx context.Context, err error, infoMsg string, retryCount int64, node *NodeConfig) (string, error) {

--- a/lib/errors.go
+++ b/lib/errors.go
@@ -107,6 +107,9 @@ func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount, 
 // triageABCIErrorCode handles specific ABCI error codes and returns appropriate processing instructions
 func triageABCIErrorCode(ctx context.Context, errorCode int, err error, infoMsg string, retryCount, retryMax int64, node *NodeConfig) (string, error) {
 	// parse error code into int32 for ABCI error code comparison
+	if errorCode < 0 || errorCode > math.MaxUint32 {
+		return ErrorProcessingFailure, errorsmod.Wrapf(err, "error code %d out of valid uint32 range", errorCode)
+	}
 	errorCodeInt32 := uint32(errorCode)
 	switch errorCodeInt32 {
 	case sdkerrors.ErrMempoolIsFull.ABCICode():

--- a/lib/errors.go
+++ b/lib/errors.go
@@ -20,14 +20,20 @@ import (
 const ErrorCodespace = "allora-offchain-lib"
 
 var (
-	ErrTooManyRequests  = errorsmod.Register(ErrorCodespace, 1, "too many requests")
-	ErrNotEnoughBalance = errorsmod.Register(ErrorCodespace, 2, "not enough balance")
-	ErrNotRegistered    = errorsmod.Register(ErrorCodespace, 3, "not registered")
-	ErrStakeBelowMin    = errorsmod.Register(ErrorCodespace, 4, "stake below minimum")
-	ErrFullMempool      = errorsmod.Register(ErrorCodespace, 5, "full mempool")
+	HTTPError            = errorsmod.Register(ErrorCodespace, 1, "http error")
+	ErrNotEnoughBalance  = errorsmod.Register(ErrorCodespace, 2, "not enough balance")
+	ErrNotRegistered     = errorsmod.Register(ErrorCodespace, 3, "not registered")
+	ErrStakeBelowMin     = errorsmod.Register(ErrorCodespace, 4, "stake below minimum")
+	ErrFullMempool       = errorsmod.Register(ErrorCodespace, 5, "full mempool")
+	ErrReadPanic         = errorsmod.Register(ErrorCodespace, 6, "read panic")
+	ErrConnectionRefused = errorsmod.Register(ErrorCodespace, 7, "connection refused")
+	ErrUnexpectedError   = errorsmod.Register(ErrorCodespace, 10, "unexpected error")
 )
 
+// Marker for ABCI error codes
 const ErrorMessageAbciErrorCodeMarker = "error code:"
+
+// Errors substrings that are not ABCI errors and do not have a specific error code
 const ErrorMessageDataAlreadySubmitted = "already submitted"
 const ErrorMessageCannotUpdateEma = "cannot update EMA"
 const ErrorMessageWaitingForNextBlock = "waiting for next block" // This means tx is accepted in mempool but not yet included in a block
@@ -35,7 +41,12 @@ const ErrorMessageAccountSequenceMismatch = "account sequence mismatch"
 const ErrorMessageTimeoutHeight = "timeout height"
 const ErrorMessageNotPermittedToSubmitPayload = "not permitted to submit payload"
 const ErrorMessageNotPermittedToAddStake = "not permitted to add stake"
+const ErrorMessageReadFlatPanic = "{ReadFlat}: panic"
+const ErrorMessageReadPerBytePanic = "{ReadPerByte}: panic"
+const ErrorMessageConnectionRefused = "connection refused"
+const ErrorMessageNoInferencesFoundForTopic = "no inferences found for topic"
 
+// Excess correction in gas for txs that are not successful
 const ExcessCorrectionInGas = 20000
 
 // Error processing types
@@ -54,7 +65,12 @@ const ErrorProcessingSwitchingNode = "switch"
 
 // HTTP status codes that trigger node switching
 var HTTPStatusCodeCodesSwitchingNode = map[int]bool{
+	403: true, // Forbidden
 	429: true, // Too Many Requests
+	502: true, // Bad Gateway
+	503: true, // Service Unavailable
+	504: true, // Gateway Timeout
+	505: true, // HTTP Version Not Supported
 }
 
 // calculateExponentialBackoffDelay returns a duration based on retry count and base delay
@@ -63,76 +79,16 @@ func calculateExponentialBackoffDelaySeconds(baseDelay int64, retryCount int64) 
 }
 
 // processError handles the error messages.
-func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount int64, node *NodeConfig) (string, error) {
+func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount, retryMax int64, node *NodeConfig) (string, error) {
 	if strings.Contains(err.Error(), ErrorMessageAbciErrorCodeMarker) {
 		re := regexp.MustCompile(`error code: '(\d+)'`)
 		matches := re.FindStringSubmatch(err.Error())
 		if len(matches) == 2 {
 			errorCode, parseErr := strconv.Atoi(matches[1])
 			if parseErr != nil {
-				log.Error().Err(parseErr).Str("msg", infoMsg).Msg("Failed to parse ABCI error code")
+				log.Error().Err(parseErr).Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Failed to parse ABCI error code")
 			} else {
-				switch errorCode {
-				case int(sdkerrors.ErrMempoolIsFull.ABCICode()):
-					log.Warn().
-						Err(err).
-						Str("msg", infoMsg).
-						Msg("Mempool is full, switching to next node")
-					return ErrorProcessingSwitchingNode, ErrFullMempool
-				case int(sdkerrors.ErrWrongSequence.ABCICode()), int(sdkerrors.ErrInvalidSequence.ABCICode()):
-					log.Warn().
-						Err(err).
-						Str("msg", infoMsg).
-						Int64("delay", node.Wallet.AccountSequenceRetryDelay).
-						Msg("Account sequence mismatch detected, retrying with fixed delay")
-					// Wait a fixed block-related waiting time
-					if DoneOrWait(ctx, node.Wallet.AccountSequenceRetryDelay) {
-						return ErrorProcessingError, ctx.Err()
-					}
-					return ErrorProcessingContinue, nil
-				case int(sdkerrors.ErrInsufficientFee.ABCICode()):
-					log.Info().
-						Err(err).
-						Str("msg", infoMsg).
-						Msg("Insufficient fees")
-					return ErrorProcessingFees, nil
-				case int(feemarkettypes.ErrNoFeeCoins.ABCICode()):
-					log.Info().
-						Err(err).
-						Str("msg", infoMsg).
-						Msg("No fee coins")
-					return ErrorProcessingFees, nil
-				case int(sdkerrors.ErrTxTooLarge.ABCICode()):
-					return ErrorProcessingError, errorsmod.Wrapf(err, "tx too large")
-				case int(sdkerrors.ErrTxInMempoolCache.ABCICode()):
-					return ErrorProcessingError, errorsmod.Wrapf(err, "tx already in mempool cache")
-				case int(sdkerrors.ErrInvalidChainID.ABCICode()):
-					return ErrorProcessingError, errorsmod.Wrapf(err, "invalid chain-id")
-				case int(sdkerrors.ErrTxTimeoutHeight.ABCICode()):
-					return ErrorProcessingFailure, errorsmod.Wrapf(err, "tx timeout height")
-				case int(emissions.ErrWorkerNonceWindowNotAvailable.ABCICode()):
-					log.Warn().
-						Err(err).
-						Str("msg", infoMsg).
-						Msg("Worker window not available, retrying with exponential backoff")
-					delay := calculateExponentialBackoffDelaySeconds(node.Wallet.RetryDelay, retryCount)
-					if DoneOrWait(ctx, delay) {
-						return ErrorProcessingError, ctx.Err()
-					}
-					return ErrorProcessingContinue, nil
-				case int(emissions.ErrReputerNonceWindowNotAvailable.ABCICode()):
-					log.Warn().
-						Err(err).
-						Str("msg", infoMsg).
-						Msg("Reputer window not available, retrying with exponential backoff")
-					delay := calculateExponentialBackoffDelaySeconds(node.Wallet.RetryDelay, retryCount)
-					if DoneOrWait(ctx, delay) {
-						return ErrorProcessingError, ctx.Err()
-					}
-					return ErrorProcessingContinue, nil
-				default:
-					log.Info().Int("errorCode", errorCode).Str("msg", infoMsg).Msg("ABCI error, but not special case - regular retry")
-				}
+				return triageABCIErrorCode(ctx, errorCode, err, infoMsg, retryCount, retryMax, node)
 			}
 		} else {
 			log.Warn().Str("msg", infoMsg).Msg("Unmatched error format, cannot classify as ABCI error")
@@ -140,25 +96,102 @@ func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount i
 	}
 
 	// Check if error is HTTP status code
-	if statusCode, statusMessage, error := ParseHTTPStatus(err.Error()); error == nil {
-		log.Warn().Int("statusCode", statusCode).Str("statusMessage", statusMessage).Str("msg", infoMsg).Msg("HTTP status code detected")
-		if statusCode, statusMessage, err := ParseHTTPStatus(err.Error()); err == nil {
-			log.Warn().Int("statusCode", statusCode).Str("statusMessage", statusMessage).Str("msg", infoMsg).Msg("HTTP status code detected")
-
-			if HTTPStatusCodeCodesSwitchingNode[statusCode] {
-				log.Warn().
-					Int("statusCode", statusCode).
-					Str("msg", infoMsg).
-					Msg("HTTP status error code detected, switching to next node")
-				return ErrorProcessingSwitchingNode, ErrTooManyRequests
-			}
-		}
+	if processingType, err := triageHTTPStatusError(err, node, infoMsg); err != nil {
+		return processingType, err
 	}
 
-	// NOT ABCI error code: keep on checking for specially handled error types
+	if processingType, err := triageStringMatchingError(ctx, err, infoMsg, node); err != nil {
+		return processingType, err
+	} else {
+		return processingType, nil
+	}
+}
+
+// triageABCIErrorCode handles specific ABCI error codes and returns appropriate processing instructions
+func triageABCIErrorCode(ctx context.Context, errorCode int, err error, infoMsg string, retryCount, retryMax int64, node *NodeConfig) (string, error) {
+	switch errorCode {
+	case int(sdkerrors.ErrMempoolIsFull.ABCICode()):
+		// Exhaust retries before switching to next node
+		if retryCount >= retryMax {
+			log.Info().
+				Err(err).
+				Str("msg", infoMsg).
+				Msg("Mempool is full, switching to next node")
+			return ErrorProcessingSwitchingNode, ErrFullMempool
+		} else {
+			delay := calculateExponentialBackoffDelaySeconds(node.Wallet.RetryDelay, retryCount)
+			if DoneOrWait(ctx, delay) {
+				return ErrorProcessingError, ctx.Err()
+			}
+			log.Info().
+				Err(err).
+				Str("msg", infoMsg).
+				Msg("Mempool is full, retrying with exponential backoff")
+			return ErrorProcessingContinue, nil
+		}
+	case int(sdkerrors.ErrWrongSequence.ABCICode()), int(sdkerrors.ErrInvalidSequence.ABCICode()):
+		log.Warn().
+			Err(err).
+			Str("msg", infoMsg).
+			Int64("delay", node.Wallet.AccountSequenceRetryDelay).
+			Msg("Account sequence mismatch detected, retrying with fixed delay")
+		// Wait a fixed block-related waiting time
+		if DoneOrWait(ctx, node.Wallet.AccountSequenceRetryDelay) {
+			return ErrorProcessingError, ctx.Err()
+		}
+		return ErrorProcessingContinue, nil
+	case int(sdkerrors.ErrInsufficientFee.ABCICode()):
+		log.Info().
+			Err(err).
+			Str("msg", infoMsg).
+			Msg("Insufficient fees")
+		return ErrorProcessingFees, nil
+	case int(feemarkettypes.ErrNoFeeCoins.ABCICode()):
+		log.Info().
+			Err(err).
+			Str("msg", infoMsg).
+			Msg("No fee coins")
+		return ErrorProcessingFees, nil
+	case int(sdkerrors.ErrTxTooLarge.ABCICode()):
+		return ErrorProcessingError, errorsmod.Wrapf(err, "tx too large")
+	case int(sdkerrors.ErrTxInMempoolCache.ABCICode()):
+		return ErrorProcessingError, errorsmod.Wrapf(err, "tx already in mempool cache")
+	case int(sdkerrors.ErrInvalidChainID.ABCICode()):
+		return ErrorProcessingError, errorsmod.Wrapf(err, "invalid chain-id")
+	case int(sdkerrors.ErrTxTimeoutHeight.ABCICode()):
+		return ErrorProcessingFailure, errorsmod.Wrapf(err, "tx timeout height")
+	case int(emissions.ErrWorkerNonceWindowNotAvailable.ABCICode()):
+		log.Warn().
+			Err(err).
+			Str("msg", infoMsg).
+			Msg("Worker window not available, retrying with exponential backoff")
+		delay := calculateExponentialBackoffDelaySeconds(node.Wallet.RetryDelay, retryCount)
+		if DoneOrWait(ctx, delay) {
+			return ErrorProcessingError, ctx.Err()
+		}
+		return ErrorProcessingContinue, nil
+	case int(emissions.ErrReputerNonceWindowNotAvailable.ABCICode()):
+		log.Warn().
+			Err(err).
+			Str("msg", infoMsg).
+			Msg("Reputer window not available, retrying with exponential backoff")
+		delay := calculateExponentialBackoffDelaySeconds(node.Wallet.RetryDelay, retryCount)
+		if DoneOrWait(ctx, delay) {
+			return ErrorProcessingError, ctx.Err()
+		}
+		return ErrorProcessingContinue, nil
+	default:
+		log.Info().Int("errorCode", errorCode).Str("msg", infoMsg).Msg("ABCI error, but not special case - regular retry")
+		return ErrorProcessingError, err
+	}
+}
+
+// Triages error by string matching
+func triageStringMatchingError(ctx context.Context, err error, infoMsg string, node *NodeConfig) (string, error) {
 	if strings.Contains(err.Error(), ErrorMessageAccountSequenceMismatch) {
 		log.Warn().
 			Err(err).
+			Str("rpc", node.RPC).
 			Str("msg", infoMsg).
 			Int64("delay", node.Wallet.AccountSequenceRetryDelay).
 			Msg("Account sequence mismatch detected, re-fetching sequence")
@@ -167,23 +200,56 @@ func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount i
 		}
 		return ErrorProcessingContinue, nil
 	} else if strings.Contains(err.Error(), ErrorMessageWaitingForNextBlock) {
-		log.Warn().Err(err).Str("msg", infoMsg).Msg("Tx accepted in mempool, it will be included in the following block(s) - not retrying")
+		log.Warn().Err(err).Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Tx accepted in mempool, it will be included in the following block(s) - not retrying")
 		return ErrorProcessingOk, nil
 	} else if strings.Contains(err.Error(), ErrorMessageDataAlreadySubmitted) || strings.Contains(err.Error(), ErrorMessageCannotUpdateEma) {
-		log.Warn().Err(err).Str("msg", infoMsg).Msg("Already submitted data for this epoch.")
+		log.Warn().Err(err).Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Already submitted data for this epoch.")
 		return ErrorProcessingOk, nil
 	} else if strings.Contains(err.Error(), ErrorMessageTimeoutHeight) {
-		log.Warn().Err(err).Str("msg", infoMsg).Msg("Tx failed because of timeout height")
+		log.Warn().Err(err).Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Tx failed because of timeout height")
 		return ErrorProcessingFailure, err
 	} else if strings.Contains(err.Error(), ErrorMessageNotPermittedToSubmitPayload) {
-		log.Warn().Err(err).Str("msg", infoMsg).Msg("Actor is not permitted to submit payload")
+		log.Warn().Err(err).Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Actor is not permitted to submit payload")
+		return ErrorProcessingFailure, err
+	} else if strings.Contains(err.Error(), ErrorMessageNoInferencesFoundForTopic) {
+		log.Warn().Err(err).Str("rpc", node.RPC).Str("msg", infoMsg).Msg("No inferences found for topic")
 		return ErrorProcessingFailure, err
 	} else if strings.Contains(err.Error(), ErrorMessageNotPermittedToAddStake) {
-		log.Warn().Err(err).Str("msg", infoMsg).Msg("Actor is not permitted to add stake")
+		log.Warn().Err(err).Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Actor is not permitted to add stake")
 		return ErrorProcessingFailure, err
+	} else if strings.Contains(err.Error(), ErrorMessageReadFlatPanic) || strings.Contains(err.Error(), ErrorMessageReadPerBytePanic) {
+		log.Warn().Err(err).Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Read panic, switching to next node")
+		return ErrorProcessingSwitchingNode, ErrReadPanic
+	} else if strings.Contains(err.Error(), ErrorMessageConnectionRefused) {
+		log.Warn().Err(err).Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Connection refused, switching to next node")
+		return ErrorProcessingSwitchingNode, ErrConnectionRefused
 	}
+	log.Info().Err(err).Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Unknown error")
+	return ErrorProcessingError, errorsmod.Wrap(ErrUnexpectedError, err.Error())
+}
 
-	return ErrorProcessingError, errorsmod.Wrapf(err, "failed to process error")
+// triageHTTPStatusError checks if the error contains an HTTP status code and determines if node switching is needed
+func triageHTTPStatusError(err error, node *NodeConfig, infoMsg string) (string, error) {
+	statusCode, statusMessage, parseErr := ParseHTTPStatus(err.Error())
+	if parseErr == nil {
+		log.Warn().
+			Int("statusCode", statusCode).
+			Str("statusMessage", statusMessage).
+			Str("msg", infoMsg).
+			Msg("HTTP status code detected")
+
+		// When status code is in the list of codes that trigger node switching, switch to next node without retries
+		if HTTPStatusCodeCodesSwitchingNode[statusCode] {
+			log.Warn().
+				Str("rpc", node.RPC).
+				Int("statusCode", statusCode).
+				Str("statusMessage", statusMessage).
+				Str("msg", infoMsg).
+				Msg("HTTP status error code detected, switching to next node")
+			return ErrorProcessingSwitchingNode, HTTPError
+		}
+	}
+	return "", nil
 }
 
 // ParseStatus parses a status code and message from a given text string.
@@ -210,5 +276,9 @@ func ParseHTTPStatus(input string) (int, string, error) {
 
 // Returns true if the error is a switching-node error
 func IsErrorSwitchingNode(err error) bool {
-	return errors.Is(err, ErrTooManyRequests) || errors.Is(err, ErrFullMempool)
+	return errors.Is(err, HTTPError) ||
+		errors.Is(err, ErrFullMempool) ||
+		errors.Is(err, ErrReadPanic) ||
+		errors.Is(err, ErrConnectionRefused) ||
+		errors.Is(err, ErrUnexpectedError)
 }

--- a/lib/errors.go
+++ b/lib/errors.go
@@ -24,6 +24,7 @@ var (
 	ErrNotEnoughBalance = errorsmod.Register(ErrorCodespace, 2, "not enough balance")
 	ErrNotRegistered    = errorsmod.Register(ErrorCodespace, 3, "not registered")
 	ErrStakeBelowMin    = errorsmod.Register(ErrorCodespace, 4, "stake below minimum")
+	ErrFullMempool      = errorsmod.Register(ErrorCodespace, 5, "full mempool")
 )
 
 const ErrorMessageAbciErrorCodeMarker = "error code:"
@@ -76,12 +77,8 @@ func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount i
 					log.Warn().
 						Err(err).
 						Str("msg", infoMsg).
-						Msg("Mempool is full, retrying with exponential backoff")
-					delay := calculateExponentialBackoffDelaySeconds(node.Wallet.RetryDelay, retryCount)
-					if DoneOrWait(ctx, delay) {
-						return ErrorProcessingError, ctx.Err()
-					}
-					return ErrorProcessingContinue, nil
+						Msg("Mempool is full, switching to next node")
+					return ErrorProcessingSwitchingNode, ErrFullMempool
 				case int(sdkerrors.ErrWrongSequence.ABCICode()), int(sdkerrors.ErrInvalidSequence.ABCICode()):
 					log.Warn().
 						Err(err).
@@ -189,10 +186,6 @@ func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount i
 	return ErrorProcessingError, errorsmod.Wrapf(err, "failed to process error")
 }
 
-// func ProcessErrorQuery(ctx context.Context, err error, infoMsg string, retryCount int64, node *NodeConfig) (string, error) {
-
-// }
-
 // ParseStatus parses a status code and message from a given text string.
 func ParseHTTPStatus(input string) (int, string, error) {
 	// Regular expression to match "Status: <code> <message>" or similar patterns in text
@@ -217,5 +210,5 @@ func ParseHTTPStatus(input string) (int, string, error) {
 
 // Returns true if the error is a switching-node error
 func IsErrorSwitchingNode(err error) bool {
-	return errors.Is(err, ErrTooManyRequests)
+	return errors.Is(err, ErrTooManyRequests) || errors.Is(err, ErrFullMempool)
 }

--- a/lib/errors.go
+++ b/lib/errors.go
@@ -92,7 +92,7 @@ func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount, 
 				if errorCode > math.MaxUint32 {
 					log.Error().Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Parsed ABCI error code exceeds uint32 bounds, skipping ABCI error code triage")
 				} else {
-					return triageABCIErrorCode(ctx, uint32(errorCode), err, infoMsg, retryCount, retryMax, node)
+					return triageABCIErrorCode(ctx, uint32(errorCode), err, infoMsg, retryCount, retryMax, node) //nolint:gosec // Safe conversion - we check bounds above
 				}
 			}
 		} else {

--- a/lib/errors.go
+++ b/lib/errors.go
@@ -101,11 +101,7 @@ func ProcessErrorTx(ctx context.Context, err error, infoMsg string, retryCount, 
 		return processingType, err
 	}
 
-	if processingType, err := triageStringMatchingError(ctx, err, infoMsg, node); err != nil {
-		return processingType, err
-	} else {
-		return processingType, nil
-	}
+	return triageStringMatchingError(ctx, err, infoMsg, node)
 }
 
 // triageABCIErrorCode handles specific ABCI error codes and returns appropriate processing instructions

--- a/lib/errors.go
+++ b/lib/errors.go
@@ -45,6 +45,7 @@ const ErrorMessageReadFlatPanic = "{ReadFlat}: panic"
 const ErrorMessageReadPerBytePanic = "{ReadPerByte}: panic"
 const ErrorMessageConnectionRefused = "connection refused"
 const ErrorMessageNoInferencesFoundForTopic = "no inferences found for topic"
+const ErrorContextDeadlineExceeded = "context deadline exceeded"
 
 // Excess correction in gas for txs that are not successful
 const ExcessCorrectionInGas = 20000
@@ -199,6 +200,9 @@ func triageStringMatchingError(ctx context.Context, err error, infoMsg string, n
 			return ErrorProcessingError, ctx.Err()
 		}
 		return ErrorProcessingContinue, nil
+	} else if strings.Contains(err.Error(), ErrorContextDeadlineExceeded) {
+		log.Warn().Err(err).Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Context deadline exceeded, switching to next node")
+		return ErrorProcessingSwitchingNode, err
 	} else if strings.Contains(err.Error(), ErrorMessageWaitingForNextBlock) {
 		log.Warn().Err(err).Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Tx accepted in mempool, it will be included in the following block(s) - not retrying")
 		return ErrorProcessingOk, nil

--- a/lib/factory_config.go
+++ b/lib/factory_config.go
@@ -37,7 +37,6 @@ func getAlloraClient(config *UserConfig, rpc string) (*cosmosclient.Client, erro
 		log.Info().Msg("Home directory does not exist, creating...")
 		err = os.MkdirAll(alloraClientHome, 0755)
 		if err != nil {
-			config.Wallet.SubmitTx = false
 			return nil, errorsmod.Wrap(err, "cannot create allora client home directory")
 		}
 		log.Info().Str("home", alloraClientHome).Msg("Allora client home directory created")
@@ -76,7 +75,6 @@ func getAlloraClient(config *UserConfig, rpc string) (*cosmosclient.Client, erro
 		cosmosclient.WithRPCClient(rpcClient),
 	)
 	if err != nil {
-		config.Wallet.SubmitTx = false
 		return nil, err
 	}
 	return &client, nil
@@ -85,7 +83,6 @@ func getAlloraClient(config *UserConfig, rpc string) (*cosmosclient.Client, erro
 func (c *UserConfig) GenerateNodeConfig(rpc string) (*NodeConfig, error) {
 	client, err := getAlloraClient(c, rpc)
 	if err != nil {
-		c.Wallet.SubmitTx = false
 		return nil, err
 	}
 	var account *cosmosaccount.Account
@@ -94,7 +91,6 @@ func (c *UserConfig) GenerateNodeConfig(rpc string) (*NodeConfig, error) {
 		// get account from the keyring
 		acc, err := client.Account(c.Wallet.AddressKeyName)
 		if err != nil {
-			c.Wallet.SubmitTx = false
 			log.Error().Err(err).Msg("could not retrieve account from keyring")
 		} else {
 			account = &acc
@@ -106,9 +102,7 @@ func (c *UserConfig) GenerateNodeConfig(rpc string) (*NodeConfig, error) {
 			if err.Error() == "account already exists" {
 				acc, err = client.Account(c.Wallet.AddressKeyName)
 			}
-
 			if err != nil {
-				c.Wallet.SubmitTx = false
 				log.Err(err).Msg("could not restore account from mnemonic")
 			} else {
 				account = &acc
@@ -126,10 +120,7 @@ func (c *UserConfig) GenerateNodeConfig(rpc string) (*NodeConfig, error) {
 
 	address, err := account.Address(ADDRESS_PREFIX)
 	if err != nil {
-		c.Wallet.SubmitTx = false
 		log.Err(err).Msg("could not retrieve allora blockchain address, transactions will not be submitted to chain")
-	} else {
-		log.Debug().Str("rpc", rpc).Str("address", address).Msg("allora blockchain address loaded")
 	}
 
 	// Create query client
@@ -162,6 +153,7 @@ func (c *UserConfig) GenerateNodeConfig(rpc string) (*NodeConfig, error) {
 	}
 
 	Node := NodeConfig{
+		RPC:     rpc,
 		Chain:   alloraChain,
 		Wallet:  c.Wallet,
 		Worker:  c.Worker,

--- a/lib/factory_config.go
+++ b/lib/factory_config.go
@@ -23,7 +23,7 @@ import (
 	jsonrpc "github.com/cometbft/cometbft/rpc/jsonrpc/client"
 )
 
-func getAlloraClient(config *UserConfig) (*cosmosclient.Client, error) {
+func getAlloraClient(config *UserConfig, rpc string) (*cosmosclient.Client, error) {
 	// create a allora client instance
 	ctx := context.Background()
 	userHomeDir, _ := os.UserHomeDir()
@@ -43,7 +43,7 @@ func getAlloraClient(config *UserConfig) (*cosmosclient.Client, error) {
 		log.Info().Str("home", alloraClientHome).Msg("Allora client home directory created")
 	}
 
-	httpClient, err := jsonrpc.DefaultHTTPClient(config.Wallet.NodeRpc)
+	httpClient, err := jsonrpc.DefaultHTTPClient(rpc)
 	if err != nil {
 		return nil, fmt.Errorf("error creating default http client")
 	}
@@ -61,13 +61,13 @@ func getAlloraClient(config *UserConfig) (*cosmosclient.Client, error) {
 		return nil, fmt.Errorf("unexpected transport type: %T", httpClient.Transport)
 	}
 
-	rpcClient, err := rpchttp.NewWithClient(config.Wallet.NodeRpc, "/websocket", httpClient)
+	rpcClient, err := rpchttp.NewWithClient(rpc, "/websocket", httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("error creating rpc client")
 	}
 
 	client, err := cosmosclient.New(ctx,
-		cosmosclient.WithNodeAddress(config.Wallet.NodeRpc),
+		cosmosclient.WithNodeAddress(rpc),
 		cosmosclient.WithAddressPrefix(ADDRESS_PREFIX),
 		cosmosclient.WithHome(alloraClientHome),
 		cosmosclient.WithGas(config.Wallet.Gas),
@@ -82,8 +82,8 @@ func getAlloraClient(config *UserConfig) (*cosmosclient.Client, error) {
 	return &client, nil
 }
 
-func (c *UserConfig) GenerateNodeConfig() (*NodeConfig, error) {
-	client, err := getAlloraClient(c)
+func (c *UserConfig) GenerateNodeConfig(rpc string) (*NodeConfig, error) {
+	client, err := getAlloraClient(c, rpc)
 	if err != nil {
 		c.Wallet.SubmitTx = false
 		return nil, err

--- a/lib/factory_config.go
+++ b/lib/factory_config.go
@@ -129,7 +129,7 @@ func (c *UserConfig) GenerateNodeConfig(rpc string) (*NodeConfig, error) {
 		c.Wallet.SubmitTx = false
 		log.Err(err).Msg("could not retrieve allora blockchain address, transactions will not be submitted to chain")
 	} else {
-		log.Info().Str("address", address).Msg("allora blockchain address loaded")
+		log.Debug().Str("rpc", rpc).Str("address", address).Msg("allora blockchain address loaded")
 	}
 
 	// Create query client
@@ -148,8 +148,7 @@ func (c *UserConfig) GenerateNodeConfig(rpc string) (*NodeConfig, error) {
 
 	c.Wallet.Address = address // Overwrite the address with the one from the keystore
 
-	log.Info().Msg("Allora client created successfully")
-	log.Info().Msg("Wallet address: " + address)
+	log.Info().Str("rpc", rpc).Str("address", address).Msg("Allora client created successfully")
 
 	alloraChain := ChainConfig{
 		Address:              address,

--- a/lib/repo_query_actor_whitelist.go
+++ b/lib/repo_query_actor_whitelist.go
@@ -21,6 +21,7 @@ func (node *NodeConfig) CanSubmitWorker(ctx context.Context, topicId emissionsty
 		},
 		query.PageRequest{}, // nolint: exhaustruct
 		"check worker whitelist",
+		node,
 	)
 	if err != nil {
 		return false, err
@@ -44,6 +45,7 @@ func (node *NodeConfig) CanSubmitReputer(ctx context.Context, topicId emissionst
 		},
 		query.PageRequest{}, // nolint: exhaustruct
 		"check reputer whitelist",
+		node,
 	)
 	if err != nil {
 		return false, err

--- a/lib/repo_query_balance.go
+++ b/lib/repo_query_balance.go
@@ -21,6 +21,7 @@ func (node *NodeConfig) GetBalance(ctx context.Context) (cosmossdk_io_math.Int, 
 		},
 		query.PageRequest{}, // nolint: exhaustruct
 		"get balance",
+		node,
 	)
 	if err != nil {
 		return cosmossdk_io_math.Int{}, err

--- a/lib/repo_query_block.go
+++ b/lib/repo_query_block.go
@@ -20,6 +20,7 @@ func (node *NodeConfig) GetReputerValuesAtBlock(ctx context.Context, topicId emi
 		},
 		query.PageRequest{}, // nolint: exhaustruct
 		"get reputer values at block",
+		node,
 	)
 	if err != nil {
 		return &emissionstypes.ValueBundle{}, err

--- a/lib/repo_query_fee.go
+++ b/lib/repo_query_fee.go
@@ -34,6 +34,7 @@ func (node *NodeConfig) GetBaseFee(ctx context.Context) (float64, error) {
 		},
 		query.PageRequest{}, // nolint:exhaustruct
 		"get base fee",
+		node,
 	)
 	if err != nil {
 		return 0, err
@@ -46,6 +47,6 @@ func (node *NodeConfig) GetBaseFee(ctx context.Context) (float64, error) {
 		return 0, fmt.Errorf("failed to parse base fee: %w", err)
 	}
 
-	log.Debug().Float64("baseFee", baseFee).Msg("Retrieved base fee from chain")
+	log.Trace().Str("rpc", node.RPC).Float64("baseFee", baseFee).Msg("Retrieved base fee from chain")
 	return baseFee, nil
 }

--- a/lib/repo_query_nonce.go
+++ b/lib/repo_query_nonce.go
@@ -20,6 +20,7 @@ func (node *NodeConfig) GetLatestOpenWorkerNonceByTopicId(ctx context.Context, t
 		},
 		query.PageRequest{}, // nolint: exhaustruct
 		"get open worker nonce",
+		node,
 	)
 	if err != nil {
 		return &emissionstypes.Nonce{}, err // nolint: exhaustruct
@@ -45,6 +46,7 @@ func (node *NodeConfig) GetOldestReputerNonceByTopicId(ctx context.Context, topi
 		},
 		query.PageRequest{}, // nolint: exhaustruct
 		"get open reputer nonce",
+		node,
 	)
 	if err != nil {
 		return &emissionstypes.Nonce{}, err // nolint: exhaustruct

--- a/lib/repo_query_registration.go
+++ b/lib/repo_query_registration.go
@@ -26,6 +26,7 @@ func (node *NodeConfig) IsWorkerRegistered(ctx context.Context, topicId uint64) 
 		},
 		query.PageRequest{}, // nolint: exhaustruct
 		"is worker registered in topic",
+		node,
 	)
 	if err != nil {
 		return false, err
@@ -52,6 +53,7 @@ func (node *NodeConfig) IsReputerRegistered(ctx context.Context, topicId uint64)
 		},
 		query.PageRequest{}, // nolint: exhaustruct
 		"is reputer registered in topic",
+		node,
 	)
 	if err != nil {
 		return false, err

--- a/lib/repo_query_stake.go
+++ b/lib/repo_query_stake.go
@@ -26,6 +26,7 @@ func (node *NodeConfig) GetReputerStakeInTopic(
 		},
 		query.PageRequest{}, // nolint: exhaustruct
 		"get reputer stake in topic",
+		node,
 	)
 	if err != nil {
 		return cosmossdk_io_math.Int{}, err

--- a/lib/repo_query_topic.go
+++ b/lib/repo_query_topic.go
@@ -21,6 +21,7 @@ func (node *NodeConfig) GetTopicInfo(ctx context.Context, topicId emissionstypes
 		},
 		query.PageRequest{}, // nolint: exhaustruct
 		"get topic info",
+		node,
 	)
 	if err != nil {
 		return nil, err

--- a/lib/repo_query_utils.go
+++ b/lib/repo_query_utils.go
@@ -2,7 +2,6 @@ package lib
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/rs/zerolog/log"
 
@@ -31,6 +30,10 @@ func QueryDataWithRetry[T any](
 		// Log the error for each retry.
 		log.Error().Err(err).Msgf("Query failed, retrying... (Retry %d/%d): %s", retryCount, maxRetries, infoMsg)
 
+		if IsErrorSwitchingNode(err) {
+			return result, err
+		}
+
 		// Wait for the uniform delay before retrying
 		if DoneOrWait(ctx, delaySeconds) {
 			break
@@ -38,5 +41,5 @@ func QueryDataWithRetry[T any](
 	}
 
 	// All retries failed, return the last error
-	return result, fmt.Errorf("query failed after %d retries: %w", maxRetries, err)
+	return result, err
 }

--- a/lib/repo_query_utils.go
+++ b/lib/repo_query_utils.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"context"
 
+	errorsmod "cosmossdk.io/errors"
 	"github.com/rs/zerolog/log"
 
 	"github.com/cosmos/cosmos-sdk/types/query"
@@ -16,6 +17,7 @@ func QueryDataWithRetry[T any](
 	queryFunc func(context.Context, query.PageRequest) (T, error),
 	req query.PageRequest,
 	infoMsg string,
+	node *NodeConfig,
 ) (T, error) {
 	var result T
 	var err error
@@ -30,8 +32,32 @@ func QueryDataWithRetry[T any](
 		// Log the error for each retry.
 		log.Error().Err(err).Msgf("Query failed, retrying... (Retry %d/%d): %s", retryCount, maxRetries, infoMsg)
 
-		if IsErrorSwitchingNode(err) {
+		errorResponse, err := ProcessErrorTx(ctx, err, infoMsg, retryCount, node.Wallet.MaxRetries, node)
+		switch errorResponse {
+		case ErrorProcessingOk:
+			return result, nil
+		case ErrorProcessingError:
+			// if error has not been handled, sleep and retry with regular delay
+			if err != nil {
+				log.Error().Err(err).Str("rpc", node.RPC).Str("msg", infoMsg).Msgf("Failed, retrying... (Retry %d/%d)", retryCount, node.Wallet.MaxRetries)
+				// Wait for the uniform delay before retrying
+				if DoneOrWait(ctx, node.Wallet.RetryDelay) {
+					return result, ctx.Err()
+				}
+				continue
+			}
+		case ErrorProcessingContinue:
+			// Error has not been handled, just continue next iteration
+			continue
+		case ErrorProcessingFees:
+			log.Debug().Msg("Query failed due to fees limit")
 			return result, err
+		case ErrorProcessingFailure:
+			return result, errorsmod.Wrapf(err, "query failed and not retried")
+		case ErrorProcessingSwitchingNode:
+			return result, err
+		default:
+			return result, errorsmod.Wrapf(err, "failed to process error")
 		}
 
 		// Wait for the uniform delay before retrying

--- a/lib/repo_tx_registration.go
+++ b/lib/repo_tx_registration.go
@@ -2,7 +2,6 @@ package lib
 
 import (
 	"context"
-	"fmt"
 
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 	"github.com/rs/zerolog/log"
@@ -11,12 +10,12 @@ import (
 // True if the actor is ultimately, definitively registered for the specified topic, else False
 // Idempotent in registration
 func (node *NodeConfig) RegisterWorkerIdempotently(ctx context.Context, config WorkerConfig) (bool, error) {
-	log := log.With().Str("rpc", node.Wallet.NodeRpc).Uint64("topicId", config.TopicId).Str("actorType", "worker").Logger()
+	log := log.With().Uint64("topicId", config.TopicId).Str("actorType", "worker").Logger()
 	log.Info().Msg("Registering worker")
 
 	isRegistered, err := node.IsWorkerRegistered(ctx, config.TopicId)
 	if err != nil {
-		log.Error().Err(err).Str("rpc", node.Wallet.NodeRpc).Msg("Could not check if the node is already registered for topic as worker, skipping")
+		log.Error().Err(err).Msg("Could not check if the node is already registered for topic as worker, skipping")
 		return false, err
 	}
 	if isRegistered {
@@ -28,7 +27,7 @@ func (node *NodeConfig) RegisterWorkerIdempotently(ctx context.Context, config W
 
 	moduleParams, err := node.Chain.EmissionsQueryClient.GetParams(ctx, &emissionstypes.GetParamsRequest{})
 	if err != nil {
-		log.Error().Err(err).Msg("Could not get chain params for node")
+		log.Error().Err(err).Msg("Could not get chain params")
 		return false, err
 	}
 
@@ -39,7 +38,7 @@ func (node *NodeConfig) RegisterWorkerIdempotently(ctx context.Context, config W
 	}
 	if !balance.GTE(moduleParams.Params.RegistrationFee) {
 		log.Error().Str("balance", balance.String()).Msg("Node does not have enough balance to register, skipping.")
-		return false, fmt.Errorf("Node does not have enough balance to register, skipping")
+		return false, ErrNotEnoughBalance
 	}
 
 	msg := &emissionstypes.RegisterRequest{
@@ -50,6 +49,10 @@ func (node *NodeConfig) RegisterWorkerIdempotently(ctx context.Context, config W
 	}
 	res, err := node.SendDataWithRetry(ctx, msg, "Register node", 0)
 	if err != nil {
+		if IsErrorSwitchingNode(err) {
+			log.Warn().Msg("Switching to next node")
+			return false, err
+		}
 
 		txHash := ""
 		if res != nil {
@@ -78,7 +81,7 @@ func (node *NodeConfig) RegisterWorkerIdempotently(ctx context.Context, config W
 // Actor may be either a worker or a reputer
 // Idempotent in registration and stake addition
 func (node *NodeConfig) RegisterAndStakeReputerIdempotently(ctx context.Context, config ReputerConfig) (bool, error) {
-	log := log.With().Str("rpc", node.Wallet.NodeRpc).Uint64("topicId", config.TopicId).Str("actorType", "reputer").Logger()
+	log := log.With().Uint64("topicId", config.TopicId).Str("actorType", "reputer").Logger()
 	log.Info().Msg("Registering reputer")
 
 	isRegistered, err := node.IsReputerRegistered(ctx, config.TopicId)
@@ -104,7 +107,7 @@ func (node *NodeConfig) RegisterAndStakeReputerIdempotently(ctx context.Context,
 		}
 		if !balance.GTE(moduleParams.Params.RegistrationFee) {
 			log.Error().Msg("Node does not have enough balance to register, skipping.")
-			return false, fmt.Errorf("Node does not have enough balance to register, skipping")
+			return false, ErrNotEnoughBalance
 		}
 
 		msgRegister := &emissionstypes.RegisterRequest{
@@ -115,7 +118,10 @@ func (node *NodeConfig) RegisterAndStakeReputerIdempotently(ctx context.Context,
 		}
 		res, err := node.SendDataWithRetry(ctx, msgRegister, "Register node", 0)
 		if err != nil {
-
+			if IsErrorSwitchingNode(err) {
+				log.Warn().Msg("Switching to next node")
+				return false, err
+			}
 			txHash := ""
 			if res != nil {
 				txHash = res.TxHash
@@ -137,7 +143,7 @@ func (node *NodeConfig) RegisterAndStakeReputerIdempotently(ctx context.Context,
 		}
 		if !isRegistered {
 			log.Error().Msg("Node not registered after all retries")
-			return false, fmt.Errorf("Node not registered after all retries")
+			return false, ErrNotRegistered
 		}
 	}
 
@@ -170,6 +176,12 @@ func (node *NodeConfig) RegisterAndStakeReputerIdempotently(ctx context.Context,
 	}
 	res, err := node.SendDataWithRetry(ctx, msgAddStake, "Add stake", 0)
 	if err != nil {
+		// Necessary to switch to next node if we get a 429 error handling control to caller
+		if IsErrorSwitchingNode(err) {
+			log.Warn().Msg("Switching to next node")
+			return false, err
+		}
+
 		txHash := ""
 		if res != nil {
 			txHash = res.TxHash
@@ -191,7 +203,7 @@ func (node *NodeConfig) RegisterAndStakeReputerIdempotently(ctx context.Context,
 	}
 	if stake.LT(minStake) {
 		log.Error().Interface("stake", stake).Interface("minStake", minStake).Msg("Stake below minimum requested stake, skipping.")
-		return false, fmt.Errorf("Stake below minimum requested stake, skipping")
+		return false, ErrStakeBelowMin
 	}
 
 	return true, nil

--- a/lib/repo_tx_registration.go
+++ b/lib/repo_tx_registration.go
@@ -15,7 +15,7 @@ func (node *NodeConfig) RegisterWorkerIdempotently(ctx context.Context, config W
 
 	isRegistered, err := node.IsWorkerRegistered(ctx, config.TopicId)
 	if err != nil {
-		log.Error().Err(err).Msg("Could not check if the node is already registered for topic as worker, skipping")
+		log.Error().Err(err).Str("rpc", node.RPC).Msg("Could not check if the node is already registered for topic as worker, skipping")
 		return false, err
 	}
 	if isRegistered {
@@ -50,7 +50,7 @@ func (node *NodeConfig) RegisterWorkerIdempotently(ctx context.Context, config W
 	res, err := node.SendDataWithRetry(ctx, msg, "Register node", 0)
 	if err != nil {
 		if IsErrorSwitchingNode(err) {
-			log.Warn().Msg("Switching to next node")
+			log.Warn().Err(err).Str("rpc", node.RPC).Msg("Error on worker registration process, switching to next node")
 			return false, err
 		}
 
@@ -65,7 +65,7 @@ func (node *NodeConfig) RegisterWorkerIdempotently(ctx context.Context, config W
 	// Give time for the tx to be included in a block
 	log.Debug().Int64("delay", node.Wallet.RetryDelay).Msg("Waiting to check registration status to be included in a block...")
 	if DoneOrWait(ctx, node.Wallet.RetryDelay) {
-		log.Error().Err(ctx.Err()).Msg("Waiting to check registration status failed")
+		log.Error().Err(ctx.Err()).Str("rpc", node.RPC).Msg("Waiting to check registration status failed")
 		return false, ctx.Err()
 	}
 	isRegistered, err = node.IsWorkerRegistered(ctx, config.TopicId)
@@ -86,7 +86,7 @@ func (node *NodeConfig) RegisterAndStakeReputerIdempotently(ctx context.Context,
 
 	isRegistered, err := node.IsReputerRegistered(ctx, config.TopicId)
 	if err != nil {
-		log.Error().Err(err).Msg("Could not check if the node is already registered for topic as reputer, skipping")
+		log.Error().Err(err).Str("rpc", node.RPC).Msg("Could not check if the node is already registered for topic as reputer, skipping")
 		return false, err
 	}
 
@@ -102,7 +102,7 @@ func (node *NodeConfig) RegisterAndStakeReputerIdempotently(ctx context.Context,
 		}
 		moduleParams, err := node.Chain.EmissionsQueryClient.GetParams(ctx, &emissionstypes.GetParamsRequest{})
 		if err != nil {
-			log.Error().Err(err).Msg("Could not get chain params for reputer")
+			log.Error().Err(err).Str("rpc", node.RPC).Msg("Could not get chain params for reputer")
 			return false, err
 		}
 		if !balance.GTE(moduleParams.Params.RegistrationFee) {
@@ -119,7 +119,7 @@ func (node *NodeConfig) RegisterAndStakeReputerIdempotently(ctx context.Context,
 		res, err := node.SendDataWithRetry(ctx, msgRegister, "Register node", 0)
 		if err != nil {
 			if IsErrorSwitchingNode(err) {
-				log.Warn().Msg("Switching to next node")
+				log.Warn().Err(err).Str("rpc", node.RPC).Msg("Error on reputer registration process, switching to next node")
 				return false, err
 			}
 			txHash := ""
@@ -133,7 +133,7 @@ func (node *NodeConfig) RegisterAndStakeReputerIdempotently(ctx context.Context,
 		// Give time for the tx to be included in a block
 		log.Debug().Int64("delay", node.Wallet.RetryDelay).Msg("Waiting to check registration status to be included in a block...")
 		if DoneOrWait(ctx, node.Wallet.RetryDelay) {
-			log.Error().Err(ctx.Err()).Msg("Waiting to check registration status failed")
+			log.Error().Err(ctx.Err()).Str("rpc", node.RPC).Msg("Waiting to check registration status failed")
 			return false, ctx.Err()
 		}
 		isRegistered, err = node.IsReputerRegistered(ctx, config.TopicId)
@@ -178,7 +178,7 @@ func (node *NodeConfig) RegisterAndStakeReputerIdempotently(ctx context.Context,
 	if err != nil {
 		// Necessary to switch to next node if we get a 429 error handling control to caller
 		if IsErrorSwitchingNode(err) {
-			log.Warn().Msg("Switching to next node")
+			log.Warn().Err(err).Str("rpc", node.RPC).Msg("Error adding stake, switching to next node")
 			return false, err
 		}
 
@@ -193,7 +193,7 @@ func (node *NodeConfig) RegisterAndStakeReputerIdempotently(ctx context.Context,
 	// Give time for the tx to be included in a block
 	log.Debug().Int64("delay", node.Wallet.RetryDelay).Msg("Waiting to check stake status to be included in a block...")
 	if DoneOrWait(ctx, node.Wallet.RetryDelay) {
-		log.Error().Err(ctx.Err()).Msg("Waiting to check stake status failed")
+		log.Error().Err(ctx.Err()).Str("rpc", node.RPC).Msg("Waiting to check stake status failed")
 		return false, ctx.Err()
 	}
 	stake, err = node.GetReputerStakeInTopic(ctx, config.TopicId, node.Chain.Address)

--- a/lib/repo_tx_utils.go
+++ b/lib/repo_tx_utils.go
@@ -17,7 +17,6 @@ import (
 // SendDataWithRetry attempts to send data, handling retries, with fee awareness.
 // Custom handling for different errors.
 func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg, infoMsg string, timeoutHeight uint64) (*cosmosclient.Response, error) {
-	var txResp *cosmosclient.Response
 	// Excess fees correction factor translated to fees using configured gas prices
 	// This value is updated by the fee price update routine - making copy for consistency within method
 	gasPrices := GetGasPrice()
@@ -76,7 +75,7 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 				errorResponse, err := ProcessErrorTx(ctx, err, infoMsg, retryCount, node.Wallet.MaxRetries, node)
 				switch errorResponse {
 				case ErrorProcessingOk:
-					return txResp, nil
+					return nil, nil
 				case ErrorProcessingError:
 					// if error has not been handled, sleep and retry with regular delay
 					if err != nil {
@@ -137,14 +136,14 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 		txResponse, err := txService.Broadcast(ctx)
 		if err == nil {
 			log.Info().Str("rpc", node.RPC).Str("msg", infoMsg).Str("txHash", txResponse.TxHash).Msg("Success")
-			return txResp, nil
+			return &txResponse, nil
 		}
 
 		// Handle error on broadcasting
 		errorResponse, err := ProcessErrorTx(ctx, err, infoMsg, retryCount, node.Wallet.MaxRetries, node)
 		switch errorResponse {
 		case ErrorProcessingOk:
-			return txResp, nil
+			return &txResponse, nil
 		case ErrorProcessingError:
 			// Error has not been handled, sleep and retry with regular delay
 			if err != nil {

--- a/lib/repo_tx_utils.go
+++ b/lib/repo_tx_utils.go
@@ -23,7 +23,7 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 	// This value is updated by the fee price update routine - making copy for consistency within method
 	gasPrices := GetGasPrice()
 
-	excessFactorFees := float64(EXCESS_CORRECTION_IN_GAS) * gasPrices
+	excessFactorFees := float64(ExcessCorrectionInGas) * gasPrices
 	// Keep track of how many times fees need to be recalculated to avoid missing fee info between errors
 	recalculateFees := 1
 	// Use to keep track of expected sequence number between errors
@@ -49,7 +49,7 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 		txService, err := node.Chain.Client.CreateTxWithOptions(ctx, node.Chain.Account, txOptions, req)
 		if err != nil {
 			// Handle error on creation of tx, before broadcasting
-			if strings.Contains(err.Error(), ERROR_MESSAGE_ACCOUNT_SEQUENCE_MISMATCH) {
+			if strings.Contains(err.Error(), ErrorMessageAccountSequenceMismatch) {
 				log.Warn().Err(err).Str("msg", infoMsg).Msg("Account sequence mismatch detected, resetting sequence")
 				expectedSeqNum, currentSeqNum, err := parseSequenceFromAccountMismatchError(err.Error())
 				if err != nil {
@@ -75,9 +75,9 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 			} else {
 				errorResponse, err := ProcessErrorTx(ctx, err, infoMsg, retryCount, node)
 				switch errorResponse {
-				case ERROR_PROCESSING_OK:
+				case ErrorProcessingOk:
 					return txResp, nil
-				case ERROR_PROCESSING_ERROR:
+				case ErrorProcessingError:
 					// if error has not been handled, sleep and retry with regular delay
 					if err != nil {
 						log.Error().Err(err).Str("msg", infoMsg).Msgf("Failed, retrying... (Retry %d/%d)", retryCount, node.Wallet.MaxRetries)
@@ -87,15 +87,15 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 						}
 						continue
 					}
-				case ERROR_PROCESSING_CONTINUE:
+				case ErrorProcessingContinue:
 					// Error has not been handled, just continue next iteration
 					continue
-				case ERROR_PROCESSING_FEES:
+				case ErrorProcessingFees:
 					// Error has not been handled, just mark as recalculate fees on this iteration
 					log.Debug().Msg("Marking fee recalculation on tx creation")
-				case ERROR_PROCESSING_FAILURE:
+				case ErrorProcessingFailure:
 					return nil, errorsmod.Wrapf(err, "tx failed and not retried")
-				case ERROR_PROCESSING_SWITCHING_NODE:
+				case ErrorProcessingSwitchingNode:
 					return nil, err
 				default:
 					return nil, errorsmod.Wrapf(err, "failed to process error")
@@ -110,7 +110,7 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 
 			// Precalculate fees
 			estimatedGas := float64(txService.Gas()) * node.Wallet.GasAdjustment
-			feesFloat := float64(estimatedGas+EXCESS_CORRECTION_IN_GAS) * gasPrices
+			feesFloat := float64(estimatedGas+ExcessCorrectionInGas) * gasPrices
 			fees := cosmossdk_io_math.NewInt(int64(feesFloat))
 			// Add excess fees correction factor to increase with each fee-problematic retry
 			feeAdjustment := int64(float64(recalculateFees) * excessFactorFees)
@@ -143,9 +143,9 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 		// Handle error on broadcasting
 		errorResponse, err := ProcessErrorTx(ctx, err, infoMsg, retryCount, node)
 		switch errorResponse {
-		case ERROR_PROCESSING_OK:
+		case ErrorProcessingOk:
 			return txResp, nil
-		case ERROR_PROCESSING_ERROR:
+		case ErrorProcessingError:
 			// Error has not been handled, sleep and retry with regular delay
 			if err != nil {
 				log.Error().Err(err).Str("msg", infoMsg).Msgf("Failed, retrying... (Retry %d/%d)", retryCount, node.Wallet.MaxRetries)
@@ -155,17 +155,17 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 				}
 				continue
 			}
-		case ERROR_PROCESSING_CONTINUE:
+		case ErrorProcessingContinue:
 			// Error has not been handled, just continue next iteration
 			continue
-		case ERROR_PROCESSING_FEES:
+		case ErrorProcessingFees:
 			// Error has not been handled, just mark as recalculate fees on this iteration
 			log.Info().Msg("Insufficient fees, marking fee recalculation on tx broadcasting for retrial")
 			recalculateFees += 1
 			continue
-		case ERROR_PROCESSING_FAILURE:
+		case ErrorProcessingFailure:
 			return nil, errorsmod.Wrapf(err, "tx failed and not retried")
-		case ERROR_PROCESSING_SWITCHING_NODE:
+		case ErrorProcessingSwitchingNode:
 			return nil, err
 		default:
 			return nil, errorsmod.Wrapf(err, "failed to process error")

--- a/lib/repo_tx_utils.go
+++ b/lib/repo_tx_utils.go
@@ -2,7 +2,6 @@ package lib
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -31,7 +30,7 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 
 	// Create tx options with timeout height if specified
 	if timeoutHeight > 0 {
-		log.Debug().Uint64("timeoutHeight", timeoutHeight).Msg("Setting timeout height for tx")
+		log.Debug().Str("rpc", node.RPC).Uint64("timeoutHeight", timeoutHeight).Msg("Setting timeout height for tx")
 		node.Chain.Client.TxFactory = node.Chain.Client.TxFactory.WithTimeoutHeight(timeoutHeight)
 	}
 
@@ -41,6 +40,7 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 		txOptions := cosmosclient.TxOptions{} // nolint: exhaustruct
 		if globalExpectedSeqNum > 0 && node.Chain.Client.TxFactory.Sequence() != globalExpectedSeqNum {
 			log.Debug().
+				Str("rpc", node.RPC).
 				Uint64("expected", globalExpectedSeqNum).
 				Uint64("current", node.Chain.Client.TxFactory.Sequence()).
 				Msg("Resetting sequence to expected from previous sequence errors")
@@ -53,7 +53,7 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 				log.Warn().Err(err).Str("msg", infoMsg).Msg("Account sequence mismatch detected, resetting sequence")
 				expectedSeqNum, currentSeqNum, err := parseSequenceFromAccountMismatchError(err.Error())
 				if err != nil {
-					log.Error().Err(err).Str("msg", infoMsg).Msg("Failed to parse sequence from error - retrying with regular delay")
+					log.Error().Err(err).Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Failed to parse sequence from error - retrying with regular delay")
 					if DoneOrWait(ctx, node.Wallet.RetryDelay) {
 						return nil, ctx.Err()
 					}
@@ -64,7 +64,7 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 				log.Info().Uint64("expected", expectedSeqNum).Uint64("current", currentSeqNum).Msg("Retrying resetting sequence from current to expected")
 				txService, err = node.Chain.Client.CreateTxWithOptions(ctx, node.Chain.Account, txOptions, req)
 				if err != nil {
-					log.Error().Err(err).Str("msg", infoMsg).Msg("Failed to reset sequence second time, retrying with regular delay")
+					log.Error().Err(err).Str("rpc", node.RPC).Str("msg", infoMsg).Msg("Failed to reset sequence second time, retrying with regular delay")
 					if DoneOrWait(ctx, node.Wallet.RetryDelay) {
 						return nil, ctx.Err()
 					}
@@ -73,14 +73,14 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 				// if creation is successful, make the expected sequence number persistent
 				globalExpectedSeqNum = expectedSeqNum
 			} else {
-				errorResponse, err := ProcessErrorTx(ctx, err, infoMsg, retryCount, node)
+				errorResponse, err := ProcessErrorTx(ctx, err, infoMsg, retryCount, node.Wallet.MaxRetries, node)
 				switch errorResponse {
 				case ErrorProcessingOk:
 					return txResp, nil
 				case ErrorProcessingError:
 					// if error has not been handled, sleep and retry with regular delay
 					if err != nil {
-						log.Error().Err(err).Str("msg", infoMsg).Msgf("Failed, retrying... (Retry %d/%d)", retryCount, node.Wallet.MaxRetries)
+						log.Error().Err(err).Str("rpc", node.RPC).Str("msg", infoMsg).Msgf("Failed, retrying... (Retry %d/%d)", retryCount, node.Wallet.MaxRetries)
 						// Wait for the uniform delay before retrying
 						if DoneOrWait(ctx, node.Wallet.RetryDelay) {
 							return nil, ctx.Err()
@@ -136,19 +136,19 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 		// Broadcast tx
 		txResponse, err := txService.Broadcast(ctx)
 		if err == nil {
-			log.Info().Str("msg", infoMsg).Str("txHash", txResponse.TxHash).Msg("Success")
+			log.Info().Str("rpc", node.RPC).Str("msg", infoMsg).Str("txHash", txResponse.TxHash).Msg("Success")
 			return txResp, nil
 		}
 
 		// Handle error on broadcasting
-		errorResponse, err := ProcessErrorTx(ctx, err, infoMsg, retryCount, node)
+		errorResponse, err := ProcessErrorTx(ctx, err, infoMsg, retryCount, node.Wallet.MaxRetries, node)
 		switch errorResponse {
 		case ErrorProcessingOk:
 			return txResp, nil
 		case ErrorProcessingError:
 			// Error has not been handled, sleep and retry with regular delay
 			if err != nil {
-				log.Error().Err(err).Str("msg", infoMsg).Msgf("Failed, retrying... (Retry %d/%d)", retryCount, node.Wallet.MaxRetries)
+				log.Error().Err(err).Str("rpc", node.RPC).Str("msg", infoMsg).Msgf("Failed, retrying... (Retry %d/%d)", retryCount, node.Wallet.MaxRetries)
 				// Wait for the uniform delay before retrying
 				if DoneOrWait(ctx, node.Wallet.RetryDelay) {
 					return nil, ctx.Err()
@@ -172,7 +172,7 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 		}
 	}
 
-	return nil, errors.New("Tx not able to complete after failing max retries")
+	return nil, errorsmod.Wrapf(ErrUnexpectedError, "Tx failed after max retries")
 }
 
 // Extract expected and current sequence numbers from the error message

--- a/lib/repo_tx_utils.go
+++ b/lib/repo_tx_utils.go
@@ -75,7 +75,7 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 				errorResponse, err := ProcessErrorTx(ctx, err, infoMsg, retryCount, node.Wallet.MaxRetries, node)
 				switch errorResponse {
 				case ErrorProcessingOk:
-					return nil, nil
+					return &cosmosclient.Response{}, nil // nolint: exhaustruct
 				case ErrorProcessingError:
 					// if error has not been handled, sleep and retry with regular delay
 					if err != nil {

--- a/lib/repo_tx_utils.go
+++ b/lib/repo_tx_utils.go
@@ -4,160 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"regexp"
 	"strconv"
 	"strings"
 
 	errorsmod "cosmossdk.io/errors"
 	cosmossdk_io_math "cosmossdk.io/math"
-	emissions "github.com/allora-network/allora-chain/x/emissions/types"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/ignite/cli/v28/ignite/pkg/cosmosclient"
 	"github.com/rs/zerolog/log"
-	feemarkettypes "github.com/skip-mev/feemarket/x/feemarket/types"
 )
-
-const ERROR_MESSAGE_ABCI_ERROR_CODE_MARKER = "error code:"
-const ERROR_MESSAGE_DATA_ALREADY_SUBMITTED = "already submitted"
-const ERROR_MESSAGE_CANNOT_UPDATE_EMA = "cannot update EMA"
-const ERROR_MESSAGE_WAITING_FOR_NEXT_BLOCK = "waiting for next block" // This means tx is accepted in mempool but not yet included in a block
-const ERROR_MESSAGE_ACCOUNT_SEQUENCE_MISMATCH = "account sequence mismatch"
-const ERROR_MESSAGE_TIMEOUT_HEIGHT = "timeout height"
-const ERROR_MESSAGE_NOT_PERMITTED_TO_SUBMIT_PAYLOAD = "not permitted to submit payload"
-const ERROR_MESSAGE_NOT_PERMITTED_TO_ADD_STAKE = "not permitted to add stake"
-
-const EXCESS_CORRECTION_IN_GAS = 20000
-
-// Error processing types
-// - "continue", nil: tx was not successful, but special error type. Handled, ready for retry
-// - "ok", nil: tx was successful, error handled and not re-raised
-// - "error", error: tx failed, with regular error type
-// - "fees": tx failed, because of insufficient fees
-// - "failure": tx failed, and should not be retried anymore
-const ERROR_PROCESSING_CONTINUE = "continue"
-const ERROR_PROCESSING_OK = "ok"
-const ERROR_PROCESSING_FEES = "fees"
-const ERROR_PROCESSING_ERROR = "error"
-const ERROR_PROCESSING_FAILURE = "failure"
-
-// calculateExponentialBackoffDelay returns a duration based on retry count and base delay
-func calculateExponentialBackoffDelaySeconds(baseDelay int64, retryCount int64) int64 {
-	return int64(math.Pow(float64(baseDelay), float64(retryCount)))
-}
-
-// processError handles the error messages.
-func processError(ctx context.Context, err error, infoMsg string, retryCount int64, node *NodeConfig) (string, error) {
-	if strings.Contains(err.Error(), ERROR_MESSAGE_ABCI_ERROR_CODE_MARKER) {
-		re := regexp.MustCompile(`error code: '(\d+)'`)
-		matches := re.FindStringSubmatch(err.Error())
-		if len(matches) == 2 {
-			errorCode, parseErr := strconv.Atoi(matches[1])
-			if parseErr != nil {
-				log.Error().Err(parseErr).Str("msg", infoMsg).Msg("Failed to parse ABCI error code")
-			} else {
-				switch errorCode {
-				case int(sdkerrors.ErrMempoolIsFull.ABCICode()):
-					log.Warn().
-						Err(err).
-						Str("msg", infoMsg).
-						Msg("Mempool is full, retrying with exponential backoff")
-					delay := calculateExponentialBackoffDelaySeconds(node.Wallet.RetryDelay, retryCount)
-					if DoneOrWait(ctx, delay) {
-						return ERROR_PROCESSING_ERROR, ctx.Err()
-					}
-					return ERROR_PROCESSING_CONTINUE, nil
-				case int(sdkerrors.ErrWrongSequence.ABCICode()), int(sdkerrors.ErrInvalidSequence.ABCICode()):
-					log.Warn().
-						Err(err).
-						Str("msg", infoMsg).
-						Int64("delay", node.Wallet.AccountSequenceRetryDelay).
-						Msg("Account sequence mismatch detected, retrying with fixed delay")
-					// Wait a fixed block-related waiting time
-					if DoneOrWait(ctx, node.Wallet.AccountSequenceRetryDelay) {
-						return ERROR_PROCESSING_ERROR, ctx.Err()
-					}
-					return ERROR_PROCESSING_CONTINUE, nil
-				case int(sdkerrors.ErrInsufficientFee.ABCICode()):
-					log.Info().
-						Err(err).
-						Str("msg", infoMsg).
-						Msg("Insufficient fees")
-					return ERROR_PROCESSING_FEES, nil
-				case int(feemarkettypes.ErrNoFeeCoins.ABCICode()):
-					log.Info().
-						Err(err).
-						Str("msg", infoMsg).
-						Msg("No fee coins")
-					return ERROR_PROCESSING_FEES, nil
-				case int(sdkerrors.ErrTxTooLarge.ABCICode()):
-					return ERROR_PROCESSING_ERROR, errorsmod.Wrapf(err, "tx too large")
-				case int(sdkerrors.ErrTxInMempoolCache.ABCICode()):
-					return ERROR_PROCESSING_ERROR, errorsmod.Wrapf(err, "tx already in mempool cache")
-				case int(sdkerrors.ErrInvalidChainID.ABCICode()):
-					return ERROR_PROCESSING_ERROR, errorsmod.Wrapf(err, "invalid chain-id")
-				case int(sdkerrors.ErrTxTimeoutHeight.ABCICode()):
-					return ERROR_PROCESSING_FAILURE, errorsmod.Wrapf(err, "tx timeout height")
-				case int(emissions.ErrWorkerNonceWindowNotAvailable.ABCICode()):
-					log.Warn().
-						Err(err).
-						Str("msg", infoMsg).
-						Msg("Worker window not available, retrying with exponential backoff")
-					delay := calculateExponentialBackoffDelaySeconds(node.Wallet.RetryDelay, retryCount)
-					if DoneOrWait(ctx, delay) {
-						return ERROR_PROCESSING_ERROR, ctx.Err()
-					}
-					return ERROR_PROCESSING_CONTINUE, nil
-				case int(emissions.ErrReputerNonceWindowNotAvailable.ABCICode()):
-					log.Warn().
-						Err(err).
-						Str("msg", infoMsg).
-						Msg("Reputer window not available, retrying with exponential backoff")
-					delay := calculateExponentialBackoffDelaySeconds(node.Wallet.RetryDelay, retryCount)
-					if DoneOrWait(ctx, delay) {
-						return ERROR_PROCESSING_ERROR, ctx.Err()
-					}
-					return ERROR_PROCESSING_CONTINUE, nil
-				default:
-					log.Info().Int("errorCode", errorCode).Str("msg", infoMsg).Msg("ABCI error, but not special case - regular retry")
-				}
-			}
-		} else {
-			log.Warn().Str("msg", infoMsg).Msg("Unmatched error format, cannot classify as ABCI error")
-		}
-	}
-
-	// NOT ABCI error code: keep on checking for specially handled error types
-	if strings.Contains(err.Error(), ERROR_MESSAGE_ACCOUNT_SEQUENCE_MISMATCH) {
-		log.Warn().
-			Err(err).
-			Str("msg", infoMsg).
-			Int64("delay", node.Wallet.AccountSequenceRetryDelay).
-			Msg("Account sequence mismatch detected, re-fetching sequence")
-		if DoneOrWait(ctx, node.Wallet.AccountSequenceRetryDelay) {
-			return ERROR_PROCESSING_ERROR, ctx.Err()
-		}
-		return ERROR_PROCESSING_CONTINUE, nil
-	} else if strings.Contains(err.Error(), ERROR_MESSAGE_WAITING_FOR_NEXT_BLOCK) {
-		log.Warn().Err(err).Str("msg", infoMsg).Msg("Tx accepted in mempool, it will be included in the following block(s) - not retrying")
-		return ERROR_PROCESSING_OK, nil
-	} else if strings.Contains(err.Error(), ERROR_MESSAGE_DATA_ALREADY_SUBMITTED) || strings.Contains(err.Error(), ERROR_MESSAGE_CANNOT_UPDATE_EMA) {
-		log.Warn().Err(err).Str("msg", infoMsg).Msg("Already submitted data for this epoch.")
-		return ERROR_PROCESSING_OK, nil
-	} else if strings.Contains(err.Error(), ERROR_MESSAGE_TIMEOUT_HEIGHT) {
-		log.Warn().Err(err).Str("msg", infoMsg).Msg("Tx failed because of timeout height")
-		return ERROR_PROCESSING_FAILURE, err
-	} else if strings.Contains(err.Error(), ERROR_MESSAGE_NOT_PERMITTED_TO_SUBMIT_PAYLOAD) {
-		log.Warn().Err(err).Str("msg", infoMsg).Msg("Actor is not permitted to submit payload")
-		return ERROR_PROCESSING_FAILURE, err
-	} else if strings.Contains(err.Error(), ERROR_MESSAGE_NOT_PERMITTED_TO_ADD_STAKE) {
-		log.Warn().Err(err).Str("msg", infoMsg).Msg("Actor is not permitted to add stake")
-		return ERROR_PROCESSING_FAILURE, err
-	}
-
-	return ERROR_PROCESSING_ERROR, errorsmod.Wrapf(err, "failed to process error")
-}
 
 // SendDataWithRetry attempts to send data, handling retries, with fee awareness.
 // Custom handling for different errors.
@@ -217,7 +73,7 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 				// if creation is successful, make the expected sequence number persistent
 				globalExpectedSeqNum = expectedSeqNum
 			} else {
-				errorResponse, err := processError(ctx, err, infoMsg, retryCount, node)
+				errorResponse, err := ProcessErrorTx(ctx, err, infoMsg, retryCount, node)
 				switch errorResponse {
 				case ERROR_PROCESSING_OK:
 					return txResp, nil
@@ -239,6 +95,8 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 					log.Debug().Msg("Marking fee recalculation on tx creation")
 				case ERROR_PROCESSING_FAILURE:
 					return nil, errorsmod.Wrapf(err, "tx failed and not retried")
+				case ERROR_PROCESSING_SWITCHING_NODE:
+					return nil, err
 				default:
 					return nil, errorsmod.Wrapf(err, "failed to process error")
 				}
@@ -283,8 +141,7 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 		}
 
 		// Handle error on broadcasting
-		log.Error().Err(err).Msg("Tx broadcast error")
-		errorResponse, err := processError(ctx, err, infoMsg, retryCount, node)
+		errorResponse, err := ProcessErrorTx(ctx, err, infoMsg, retryCount, node)
 		switch errorResponse {
 		case ERROR_PROCESSING_OK:
 			return txResp, nil
@@ -308,6 +165,8 @@ func (node *NodeConfig) SendDataWithRetry(ctx context.Context, req sdktypes.Msg,
 			continue
 		case ERROR_PROCESSING_FAILURE:
 			return nil, errorsmod.Wrapf(err, "tx failed and not retried")
+		case ERROR_PROCESSING_SWITCHING_NODE:
+			return nil, err
 		default:
 			return nil, errorsmod.Wrapf(err, "failed to process error")
 		}

--- a/main.go
+++ b/main.go
@@ -109,6 +109,7 @@ func main() {
 		log.Fatal().Err(err).Msg("Failed to convert Entrypoints to instances of adapters - wrong entrypoint name?")
 		return
 	}
+
 	spawner, err := usecase.NewUseCaseSuite(finalUserConfig)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to initialize use case, exiting")

--- a/usecase/build_commit_reputer_payload.go
+++ b/usecase/build_commit_reputer_payload.go
@@ -69,6 +69,7 @@ func (suite *UseCaseSuite) BuildCommitReputerPayload(ctx context.Context, repute
 	} else {
 		log.Debug().Msgf("Sending InsertReputerPayload to chain %s", string(reqJSON))
 	}
+
 	if suite.RPCManager.GetCurrentNode().Wallet.SubmitTx {
 		_, err = suite.RPCManager.SendDataWithNodeRetry(ctx, req, timeoutHeight, "Send Reputer Data to chain")
 		if err != nil {

--- a/usecase/build_commit_reputer_payload.go
+++ b/usecase/build_commit_reputer_payload.go
@@ -21,26 +21,34 @@ import (
 func (suite *UseCaseSuite) BuildCommitReputerPayload(ctx context.Context, reputer lib.ReputerConfig, nonce lib.BlockHeight, timeoutHeight uint64) error {
 	log := log.With().Uint64("topicId", reputer.TopicId).Str("actorType", "reputer").Logger()
 	log.Info().Msg("Building reputer payload")
-	valueBundle, err := suite.Node.GetReputerValuesAtBlock(ctx, reputer.TopicId, nonce)
+
+	valueBundle, err := RunWithNodeRetry(
+		ctx,
+		suite.RPCManager,
+		func(node *lib.NodeConfig) (*emissionstypes.ValueBundle, error) {
+			return node.GetReputerValuesAtBlock(ctx, reputer.TopicId, nonce)
+		},
+		"get reputer values",
+	)
 	if err != nil {
 		return errorsmod.Wrapf(err, "error getting reputer values, topic: %d, blockHeight: %d", reputer.TopicId, nonce)
 	}
 	valueBundle.ReputerRequestNonce = &emissionstypes.ReputerRequestNonce{
 		ReputerNonce: &emissionstypes.Nonce{BlockHeight: nonce},
 	}
-	valueBundle.Reputer = suite.Node.Wallet.Address
+	valueBundle.Reputer = suite.RPCManager.GetCurrentNode().Wallet.Address
 
 	sourceTruth, err := reputer.GroundTruthEntrypoint.GroundTruth(reputer, nonce)
 	if err != nil {
 		return errorsmod.Wrapf(err, "error getting source truth from reputer, topicId: %d, blockHeight: %d", reputer.TopicId, nonce)
 	}
-	suite.Metrics.IncrementMetricsCounter(lib.TruthRequestCount, suite.Node.Chain.Address, reputer.TopicId)
+	suite.Metrics.IncrementMetricsCounter(lib.TruthRequestCount, suite.RPCManager.GetCurrentNode().Chain.Address, reputer.TopicId)
 
 	lossBundle, err := suite.ComputeLossBundle(sourceTruth, valueBundle, reputer)
 	if err != nil {
 		return errorsmod.Wrapf(err, "error computing loss bundle, topic: %d, blockHeight: %d", reputer.TopicId, nonce)
 	}
-	suite.Metrics.IncrementMetricsCounter(lib.ReputerDataBuildCount, suite.Node.Chain.Address, reputer.TopicId)
+	suite.Metrics.IncrementMetricsCounter(lib.ReputerDataBuildCount, suite.RPCManager.GetCurrentNode().Chain.Address, reputer.TopicId)
 
 	signedValueBundle, err := suite.SignReputerValueBundle(&lossBundle)
 	if err != nil {
@@ -52,7 +60,7 @@ func (suite *UseCaseSuite) BuildCommitReputerPayload(ctx context.Context, repute
 	}
 
 	req := &emissionstypes.InsertReputerPayloadRequest{
-		Sender:             suite.Node.Wallet.Address,
+		Sender:             suite.RPCManager.GetCurrentNode().Wallet.Address,
 		ReputerValueBundle: signedValueBundle,
 	}
 	reqJSON, err := json.Marshal(req)
@@ -61,12 +69,12 @@ func (suite *UseCaseSuite) BuildCommitReputerPayload(ctx context.Context, repute
 	} else {
 		log.Debug().Msgf("Sending InsertReputerPayload to chain %s", string(reqJSON))
 	}
-	if suite.Node.Wallet.SubmitTx {
-		_, err = suite.Node.SendDataWithRetry(ctx, req, "Send Reputer Data to chain", timeoutHeight)
+	if suite.RPCManager.GetCurrentNode().Wallet.SubmitTx {
+		_, err = suite.RPCManager.SendDataWithNodeRetry(ctx, req, timeoutHeight, "Send Reputer Data to chain")
 		if err != nil {
 			return errorsmod.Wrapf(err, "error sending Reputer Data to chain, topic: %d, blockHeight: %d", reputer.TopicId, nonce)
 		}
-		suite.Metrics.IncrementMetricsCounter(lib.ReputerChainSubmissionCount, suite.Node.Chain.Address, reputer.TopicId)
+		suite.Metrics.IncrementMetricsCounter(lib.ReputerChainSubmissionCount, suite.RPCManager.GetCurrentNode().Chain.Address, reputer.TopicId)
 	} else {
 		log.Info().Msg("SubmitTx=false; Skipping sending Reputer Data to chain")
 	}
@@ -209,7 +217,8 @@ func (suite *UseCaseSuite) SignReputerValueBundle(valueBundle *emissionstypes.Va
 	if err != nil {
 		return &emissionstypes.ReputerValueBundle{}, errorsmod.Wrapf(err, "error marshalling valueBundle")
 	}
-	sig, pk, err := suite.Node.Chain.Client.Context().Keyring.Sign(suite.Node.Chain.Account.Name, protoBytesIn, signing.SignMode_SIGN_MODE_DIRECT)
+	sig, pk, err := suite.RPCManager.GetCurrentNode().Chain.Client.Context().Keyring.
+		Sign(suite.RPCManager.GetCurrentNode().Chain.Account.Name, protoBytesIn, signing.SignMode_SIGN_MODE_DIRECT)
 	if err != nil {
 		return &emissionstypes.ReputerValueBundle{}, errorsmod.Wrapf(err, "error signing valueBundle")
 	}

--- a/usecase/build_commit_worker_payload.go
+++ b/usecase/build_commit_worker_payload.go
@@ -33,7 +33,7 @@ func (suite *UseCaseSuite) BuildCommitWorkerPayload(ctx context.Context, worker 
 			return errorsmod.Wrapf(err, "Error computing inference for worker, topicId: %d, blockHeight: %d", worker.TopicId, nonce.BlockHeight)
 		}
 		workerResponse.InfererValue = inference
-		suite.Metrics.IncrementMetricsCounter(lib.InferenceRequestCount, suite.Node.Chain.Address, worker.TopicId)
+		suite.Metrics.IncrementMetricsCounter(lib.InferenceRequestCount, suite.RPCManager.GetCurrentNode().Chain.Address, worker.TopicId)
 	}
 
 	if worker.ForecastEntrypoint != nil {
@@ -42,14 +42,14 @@ func (suite *UseCaseSuite) BuildCommitWorkerPayload(ctx context.Context, worker 
 			return errorsmod.Wrapf(err, "Error computing forecast for worker, topicId: %d, blockHeight: %d", worker.TopicId, nonce.BlockHeight)
 		}
 		workerResponse.ForecasterValues = forecasts
-		suite.Metrics.IncrementMetricsCounter(lib.ForecastRequestCount, suite.Node.Chain.Address, worker.TopicId)
+		suite.Metrics.IncrementMetricsCounter(lib.ForecastRequestCount, suite.RPCManager.GetCurrentNode().Chain.Address, worker.TopicId)
 	}
 
 	workerPayload, err := suite.BuildWorkerPayload(workerResponse, nonce.BlockHeight)
 	if err != nil {
 		return errorsmod.Wrapf(err, "Error building worker payload, topicId: %d, blockHeight: %d", worker.TopicId, nonce.BlockHeight)
 	}
-	suite.Metrics.IncrementMetricsCounter(lib.WorkerDataBuildCount, suite.Node.Chain.Address, worker.TopicId)
+	suite.Metrics.IncrementMetricsCounter(lib.WorkerDataBuildCount, suite.RPCManager.GetCurrentNode().Chain.Address, worker.TopicId)
 
 	workerDataBundle, err := suite.SignWorkerPayload(&workerPayload)
 	if err != nil {
@@ -63,7 +63,7 @@ func (suite *UseCaseSuite) BuildCommitWorkerPayload(ctx context.Context, worker 
 	}
 
 	req := &emissionstypes.InsertWorkerPayloadRequest{
-		Sender:           suite.Node.Wallet.Address,
+		Sender:           suite.RPCManager.GetCurrentNode().Wallet.Address,
 		WorkerDataBundle: workerDataBundle,
 	}
 	reqJSON, err := json.Marshal(req)
@@ -73,12 +73,12 @@ func (suite *UseCaseSuite) BuildCommitWorkerPayload(ctx context.Context, worker 
 		log.Info().Str("req", string(reqJSON)).Msg("Sending InsertWorkerPayload to chain")
 	}
 
-	if suite.Node.Wallet.SubmitTx {
-		_, err = suite.Node.SendDataWithRetry(ctx, req, "Send Worker Data to chain", timeoutHeight)
+	if suite.RPCManager.GetCurrentNode().Wallet.SubmitTx {
+		_, err = suite.RPCManager.SendDataWithNodeRetry(ctx, req, timeoutHeight, "Send Worker Data to chain")
 		if err != nil {
 			return errorsmod.Wrapf(err, "Error sending Worker Data to chain, topicId: %d, blockHeight: %d", worker.TopicId, nonce.BlockHeight)
 		}
-		suite.Metrics.IncrementMetricsCounter(lib.WorkerChainSubmissionCount, suite.Node.Chain.Address, worker.TopicId)
+		suite.Metrics.IncrementMetricsCounter(lib.WorkerChainSubmissionCount, suite.RPCManager.GetCurrentNode().Chain.Address, worker.TopicId)
 	} else {
 		log.Info().Msg("SubmitTx=false; Skipping sending Worker Data to chain")
 	}
@@ -96,7 +96,7 @@ func (suite *UseCaseSuite) BuildWorkerPayload(workerResponse lib.WorkerResponse,
 		}
 		builtInference := &emissionstypes.Inference{ // nolint: exhaustruct
 			TopicId:     workerResponse.TopicId,
-			Inferer:     suite.Node.Wallet.Address,
+			Inferer:     suite.RPCManager.GetCurrentNode().Wallet.Address,
 			Value:       infererValue,
 			BlockHeight: nonce,
 		}
@@ -120,7 +120,7 @@ func (suite *UseCaseSuite) BuildWorkerPayload(workerResponse lib.WorkerResponse,
 			forecasterValues := &emissionstypes.Forecast{ // nolint: exhaustruct
 				TopicId:          workerResponse.TopicId,
 				BlockHeight:      nonce,
-				Forecaster:       suite.Node.Wallet.Address,
+				Forecaster:       suite.RPCManager.GetCurrentNode().Wallet.Address,
 				ForecastElements: forecasterElements,
 			}
 			inferenceForecastsBundle.Forecast = forecasterValues
@@ -136,14 +136,14 @@ func (suite *UseCaseSuite) SignWorkerPayload(workerPayload *emissionstypes.Infer
 	if err != nil {
 		return &emissionstypes.WorkerDataBundle{}, errorsmod.Wrapf(err, "error marshalling workerPayload") // nolint: exhaustruct
 	}
-	sig, pk, err := suite.Node.Chain.Client.Context().Keyring.Sign(suite.Node.Chain.Account.Name, protoBytesIn, signing.SignMode_SIGN_MODE_DIRECT)
+	sig, pk, err := suite.RPCManager.GetCurrentNode().Chain.Client.Context().Keyring.Sign(suite.RPCManager.GetCurrentNode().Chain.Account.Name, protoBytesIn, signing.SignMode_SIGN_MODE_DIRECT)
 	if err != nil {
 		return &emissionstypes.WorkerDataBundle{}, errorsmod.Wrapf(err, "error signing the InferenceForecastsBundle message") // nolint: exhaustruct
 	}
 	pkStr := hex.EncodeToString(pk.Bytes())
 	// Create workerDataBundle with signature
 	workerDataBundle := &emissionstypes.WorkerDataBundle{ // nolint: exhaustruct
-		Worker:                             suite.Node.Wallet.Address,
+		Worker:                             suite.RPCManager.GetCurrentNode().Wallet.Address,
 		InferenceForecastsBundle:           workerPayload,
 		InferencesForecastsBundleSignature: sig,
 		Pubkey:                             pkStr,

--- a/usecase/build_commit_worker_payload_test.go
+++ b/usecase/build_commit_worker_payload_test.go
@@ -121,8 +121,17 @@ func TestComputeWorkerBundle(t *testing.T) {
 			tt.workerConfig.InferenceEntrypoint = mockAdapter
 			tt.workerConfig.ForecastEntrypoint = mockAdapter
 
-			suite := &UseCaseSuite{} // nolint: exhaustruct
-			suite.Node.Wallet.Address = tt.address
+			// Replace RPCManager creation with mock
+			mockRPCManager := &MockRPCManager{}
+			mockNodeConfig := &lib.NodeConfig{
+				Wallet: lib.WalletConfig{
+					Address: tt.address,
+				},
+			}
+			mockRPCManager.On("GetCurrentNode").Return(mockNodeConfig)
+			suite := &UseCaseSuite{RPCManager: mockRPCManager} // nolint: exhaustruct
+
+			suite.RPCManager.GetCurrentNode().Wallet.Address = tt.address
 			response, err := suite.BuildWorkerPayload(tt.workerConfig, 1)
 			if tt.expectError {
 				require.Error(t, err)

--- a/usecase/build_commit_worker_payload_test.go
+++ b/usecase/build_commit_worker_payload_test.go
@@ -122,9 +122,9 @@ func TestComputeWorkerBundle(t *testing.T) {
 			tt.workerConfig.ForecastEntrypoint = mockAdapter
 
 			// Replace RPCManager creation with mock
-			mockRPCManager := &MockRPCManager{}
-			mockNodeConfig := &lib.NodeConfig{
-				Wallet: lib.WalletConfig{
+			mockRPCManager := &MockRPCManager{} //nolint:exhaustruct
+			mockNodeConfig := &lib.NodeConfig{  //nolint:exhaustruct
+				Wallet: lib.WalletConfig{ //nolint:exhaustruct
 					Address: tt.address,
 				},
 			}

--- a/usecase/errors.go
+++ b/usecase/errors.go
@@ -1,0 +1,11 @@
+package usecase
+
+import (
+	errorsmod "cosmossdk.io/errors"
+)
+
+const ERROR_CODESPACE = "allora-offchain-usecase"
+
+var (
+	ErrAllNodesExhausted = errorsmod.Register(ERROR_CODESPACE, 1, "all available nodes have been tried and exhausted")
+)

--- a/usecase/gas_price_routine.go
+++ b/usecase/gas_price_routine.go
@@ -11,23 +11,30 @@ import (
 
 // UpdateGasPriceRoutine continuously updates the gas price at a specified interval
 func (suite *UseCaseSuite) UpdateGasPriceRoutine(ctx context.Context) {
-	log.Info().Msg("Starting gas price routine")
 	for {
 		select {
 		case <-ctx.Done():
 			log.Info().Msg("Updating fee price routine: terminating.")
 			return
 		default:
-			price, err := WithTimeoutResult(ctx, time.Duration(suite.Node.Wallet.TimeoutRPCSecondsQuery)*time.Second,
-				func(ctx context.Context) (float64, error) {
-					return suite.Node.GetBaseFee(ctx)
-				})
+			price, err := RunWithNodeRetry(
+				ctx,
+				suite.RPCManager,
+				func(node *lib.NodeConfig) (float64, error) {
+					return WithTimeoutResult(ctx,
+						time.Duration(suite.RPCManager.GetCurrentNode().Wallet.TimeoutRPCSecondsQuery)*time.Second,
+						func(ctx context.Context) (float64, error) {
+							return suite.RPCManager.GetCurrentNode().GetBaseFee(ctx)
+						})
+				},
+				"get base fee",
+			)
 			if err != nil {
 				log.Error().Err(err).Msg("Error updating gas prices")
 			}
 			lib.SetGasPrice(price)
 			log.Debug().Float64("gasPrice", lib.GetGasPrice()).Msg("Updating fee price routine: updating value.")
-			time.Sleep(time.Duration(suite.Node.Wallet.GasPriceUpdateInterval) * time.Second)
+			time.Sleep(time.Duration(suite.RPCManager.GetCurrentNode().Wallet.GasPriceUpdateInterval) * time.Second)
 		}
 	}
 }

--- a/usecase/mock_rpc_manager.go
+++ b/usecase/mock_rpc_manager.go
@@ -1,0 +1,51 @@
+package usecase
+
+import (
+	"allora_offchain_node/lib"
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ignite/cli/v28/ignite/pkg/cosmosclient"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockRPCManager struct {
+	mock.Mock
+}
+
+func (m *MockRPCManager) GetCurrentNode() *lib.NodeConfig {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(*lib.NodeConfig)
+}
+
+func (m *MockRPCManager) SwitchToNextNode() *lib.NodeConfig {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(*lib.NodeConfig)
+}
+
+func (m *MockRPCManager) GetStats() (int, map[int]int) {
+	args := m.Called()
+	return args.Int(0), args.Get(1).(map[int]int)
+}
+
+func (m *MockRPCManager) GetNodes() ([]lib.NodeConfig, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]lib.NodeConfig), args.Error(1)
+}
+
+func (m *MockRPCManager) SendDataWithNodeRetry(ctx context.Context, msg sdk.Msg, timeoutHeight uint64, operationName string) (*cosmosclient.Response, error) {
+	args := m.Called(ctx, msg, timeoutHeight, operationName)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*cosmosclient.Response), args.Error(1)
+}

--- a/usecase/mock_rpc_manager.go
+++ b/usecase/mock_rpc_manager.go
@@ -70,3 +70,14 @@ func (m *MockRPCManager) GetCurrentIndex() int {
 	args := m.Called()
 	return args.Int(0)
 }
+
+func (m *MockRPCManager) SwitchToNode(index int) *lib.NodeConfig {
+	args := m.Called(index)
+	if args.Get(0) == nil {
+		return nil
+	}
+	if node, ok := args.Get(0).(*lib.NodeConfig); ok {
+		return node
+	}
+	return nil
+}

--- a/usecase/mock_rpc_manager.go
+++ b/usecase/mock_rpc_manager.go
@@ -18,7 +18,10 @@ func (m *MockRPCManager) GetCurrentNode() *lib.NodeConfig {
 	if args.Get(0) == nil {
 		return nil
 	}
-	return args.Get(0).(*lib.NodeConfig)
+	if node, ok := args.Get(0).(*lib.NodeConfig); ok {
+		return node
+	}
+	return nil
 }
 
 func (m *MockRPCManager) SwitchToNextNode() *lib.NodeConfig {
@@ -26,12 +29,19 @@ func (m *MockRPCManager) SwitchToNextNode() *lib.NodeConfig {
 	if args.Get(0) == nil {
 		return nil
 	}
-	return args.Get(0).(*lib.NodeConfig)
+	if node, ok := args.Get(0).(*lib.NodeConfig); ok {
+		return node
+	}
+	return nil
 }
 
 func (m *MockRPCManager) GetStats() (int, map[int]int) {
 	args := m.Called()
-	return args.Int(0), args.Get(1).(map[int]int)
+	failures, ok := args.Get(1).(map[int]int)
+	if !ok {
+		return args.Int(0), make(map[int]int)
+	}
+	return args.Int(0), failures
 }
 
 func (m *MockRPCManager) GetNodes() ([]lib.NodeConfig, error) {
@@ -39,7 +49,10 @@ func (m *MockRPCManager) GetNodes() ([]lib.NodeConfig, error) {
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	return args.Get(0).([]lib.NodeConfig), args.Error(1)
+	if nodes, ok := args.Get(0).([]lib.NodeConfig); ok {
+		return nodes, args.Error(1)
+	}
+	return nil, args.Error(1)
 }
 
 func (m *MockRPCManager) SendDataWithNodeRetry(ctx context.Context, msg sdk.Msg, timeoutHeight uint64, operationName string) (*cosmosclient.Response, error) {
@@ -47,5 +60,8 @@ func (m *MockRPCManager) SendDataWithNodeRetry(ctx context.Context, msg sdk.Msg,
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	return args.Get(0).(*cosmosclient.Response), args.Error(1)
+	if response, ok := args.Get(0).(*cosmosclient.Response); ok {
+		return response, args.Error(1)
+	}
+	return nil, args.Error(1)
 }

--- a/usecase/mock_rpc_manager.go
+++ b/usecase/mock_rpc_manager.go
@@ -65,3 +65,8 @@ func (m *MockRPCManager) SendDataWithNodeRetry(ctx context.Context, msg sdk.Msg,
 	}
 	return nil, args.Error(1)
 }
+
+func (m *MockRPCManager) GetCurrentIndex() int {
+	args := m.Called()
+	return args.Int(0)
+}

--- a/usecase/rpc_manager.go
+++ b/usecase/rpc_manager.go
@@ -1,0 +1,241 @@
+package usecase
+
+import (
+	"allora_offchain_node/lib"
+	"context"
+	"fmt"
+	"net/url"
+	"sync"
+
+	errorsmod "cosmossdk.io/errors"
+	"github.com/ignite/cli/v28/ignite/pkg/cosmosclient"
+	"github.com/rs/zerolog/log"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type RPCManagerInterface interface {
+	GetCurrentNode() *lib.NodeConfig
+	SwitchToNextNode() *lib.NodeConfig
+	GetStats() (int, map[int]int)
+	SendDataWithNodeRetry(ctx context.Context, msg sdk.Msg, timeoutHeight uint64, operationName string) (*cosmosclient.Response, error)
+	GetNodes() ([]lib.NodeConfig, error)
+}
+
+type RPCManager struct {
+	nodes      []lib.NodeConfig
+	currentIdx int
+	mu         sync.RWMutex
+	stats      RPCStats
+}
+
+type RPCStats struct {
+	nodeFailures map[int]int
+	nodeSwitches int
+	mu           sync.RWMutex
+}
+
+func (r *RPCManager) GetNodes() ([]lib.NodeConfig, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.nodes, nil
+}
+
+// newRPCManager is now private, used internally by InitRPCManager
+func NewRPCManager(userConfig lib.UserConfig) (*RPCManager, error) {
+	if len(userConfig.Wallet.NodeRPCs) == 0 {
+		return nil, fmt.Errorf("no RPC nodes provided")
+	}
+
+	validatedNodes, err := validateAndDeduplicateNodes(userConfig.Wallet.NodeRPCs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load here the nodeconfigs
+	var nodes []lib.NodeConfig
+	for _, rpc := range validatedNodes {
+		log.Info().Str("rpc", rpc).Msg("Initializing rpc")
+		nodeConfig, err := userConfig.GenerateNodeConfig(rpc)
+		if err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, *nodeConfig)
+	}
+
+	return &RPCManager{
+		nodes:      nodes,
+		currentIdx: 0,
+		stats: RPCStats{
+			nodeFailures: make(map[int]int),
+		},
+	}, nil
+}
+
+func validateAndDeduplicateNodes(nodes []string) ([]string, error) {
+	seen := make(map[string]bool)
+	validated := make([]string, 0)
+
+	for _, node := range nodes {
+		// Validate URL
+		_, err := url.ParseRequestURI(node)
+		if err != nil {
+			return nil, fmt.Errorf("invalid RPC URL %s: %w", node, err)
+		}
+
+		// Deduplicate
+		if !seen[node] {
+			seen[node] = true
+			validated = append(validated, node)
+		}
+	}
+
+	return validated, nil
+}
+
+func (rm *RPCManager) GetCurrentNode() *lib.NodeConfig {
+	rm.mu.RLock()
+	defer rm.mu.RUnlock()
+	return &rm.nodes[rm.currentIdx]
+}
+
+func (rm *RPCManager) SwitchToNextNode() *lib.NodeConfig {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+
+	oldIndex := rm.currentIdx
+	rm.currentIdx = (rm.currentIdx + 1) % len(rm.nodes)
+	newNode := rm.nodes[rm.currentIdx]
+
+	// Update stats
+	rm.stats.mu.Lock()
+	rm.stats.nodeFailures[oldIndex]++
+	rm.stats.nodeSwitches++
+	rm.stats.mu.Unlock()
+
+	log.Warn().
+		Int("from_node", oldIndex).
+		Int("to_node", rm.currentIdx).
+		Int("total_switches", rm.stats.nodeSwitches).
+		Int("node_failures", rm.stats.nodeFailures[oldIndex]).
+		Msg("Switching to next RPC node")
+
+	return &newNode
+}
+
+func (rm *RPCManager) GetStats() (int, map[int]int) {
+	rm.stats.mu.RLock()
+	defer rm.stats.mu.RUnlock()
+
+	// Create a copy of the stats to return
+	failuresCopy := make(map[int]int)
+	for k, v := range rm.stats.nodeFailures {
+		failuresCopy[k] = v
+	}
+
+	return rm.stats.nodeSwitches, failuresCopy
+}
+
+// SendDataWithNodeRetry attempts to send data to the chain, switching nodes if necessary
+func (r *RPCManager) SendDataWithNodeRetry(
+	ctx context.Context,
+	msg sdk.Msg,
+	timeoutHeight uint64,
+	operationName string,
+) (*cosmosclient.Response, error) {
+	// Track which nodes we've tried
+	triedNodes := make(map[string]bool)
+	totalNodes := len(r.nodes)
+
+	for attempts := 0; attempts < totalNodes; attempts++ {
+		currentNode := r.GetCurrentNode()
+		nodeKey := currentNode.Chain.Address
+
+		// Skip if we've already tried this node
+		if triedNodes[nodeKey] {
+			r.SwitchToNextNode()
+			continue
+		}
+
+		// Mark this node as tried
+		triedNodes[nodeKey] = true
+
+		// Attempt to send data using existing retry mechanism
+		res, err := currentNode.SendDataWithRetry(ctx, msg, operationName, timeoutHeight)
+		if err == nil {
+			return res, nil
+		}
+
+		// If it's a node switching error, switch to next node and continue
+		if lib.IsErrorSwitchingNode(err) {
+			log.Warn().
+				Str("node", nodeKey).
+				Str("operation", operationName).
+				Msg("Switching to next node")
+			r.SwitchToNextNode()
+			continue
+		}
+
+		// For any other error, return it immediately
+		return nil, errorsmod.Wrapf(err, "error during %s", operationName)
+	}
+
+	// If we've tried all nodes and none worked
+	return nil, errorsmod.Wrapf(ErrAllNodesExhausted,
+		"tried %d nodes during %s", totalNodes, operationName)
+}
+
+// RunWithNodeRetry executes an operation that returns (T, error) on nodes until success or all nodes are exhausted
+func RunWithNodeRetry[T any](
+	ctx context.Context,
+	r RPCManagerInterface,
+	operation func(*lib.NodeConfig) (T, error),
+	operationName string,
+) (T, error) {
+	var zeroValue T
+
+	// Track which nodes we've tried
+	triedNodes := make(map[string]bool)
+	nodes, err := r.GetNodes()
+	if err != nil {
+		return zeroValue, errorsmod.Wrapf(err, "error getting nodes")
+	}
+	totalNodes := len(nodes)
+
+	for attempts := 0; attempts < totalNodes; attempts++ {
+		currentNode := r.GetCurrentNode()
+		nodeKey := currentNode.Chain.Address
+
+		// Skip if we've already tried this node
+		if triedNodes[nodeKey] {
+			r.SwitchToNextNode()
+			continue
+		}
+
+		// Mark this node as tried
+		triedNodes[nodeKey] = true
+
+		// Attempt operation on current node
+		result, err := operation(currentNode)
+		if err == nil {
+			return result, nil
+		}
+
+		// If it's a node switching error, switch to next node and continue
+		if lib.IsErrorSwitchingNode(err) {
+			log.Warn().
+				Str("node", nodeKey).
+				Str("operation", operationName).
+				Msg("Switching to next node")
+			r.SwitchToNextNode()
+			continue
+		}
+
+		// For any other error, return it immediately
+		return zeroValue, errorsmod.Wrapf(err, "error during %s", operationName)
+	}
+
+	// If we've tried all nodes and none worked
+	return zeroValue, errorsmod.Wrapf(ErrAllNodesExhausted,
+		"tried %d nodes during %s", totalNodes, operationName)
+}

--- a/usecase/rpc_manager.go
+++ b/usecase/rpc_manager.go
@@ -63,12 +63,13 @@ func NewRPCManager(userConfig lib.UserConfig) (*RPCManager, error) {
 		nodes = append(nodes, *nodeConfig)
 	}
 
-	return &RPCManager{
+	return &RPCManager{ // nolint: exhaustruct
 		nodes:      nodes,
 		currentIdx: 0,
-		stats: RPCStats{
+		stats: RPCStats{ // nolint: exhaustruct
 			nodeFailures: make(map[int]int),
 		},
+		// no need to init mu
 	}, nil
 }
 
@@ -93,47 +94,47 @@ func validateAndDeduplicateNodes(nodes []string) ([]string, error) {
 	return validated, nil
 }
 
-func (rm *RPCManager) GetCurrentNode() *lib.NodeConfig {
-	rm.mu.RLock()
-	defer rm.mu.RUnlock()
-	return &rm.nodes[rm.currentIdx]
+func (r *RPCManager) GetCurrentNode() *lib.NodeConfig {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return &r.nodes[r.currentIdx]
 }
 
-func (rm *RPCManager) SwitchToNextNode() *lib.NodeConfig {
-	rm.mu.Lock()
-	defer rm.mu.Unlock()
+func (r *RPCManager) SwitchToNextNode() *lib.NodeConfig {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
-	oldIndex := rm.currentIdx
-	rm.currentIdx = (rm.currentIdx + 1) % len(rm.nodes)
-	newNode := rm.nodes[rm.currentIdx]
+	oldIndex := r.currentIdx
+	r.currentIdx = (r.currentIdx + 1) % len(r.nodes)
+	newNode := r.nodes[r.currentIdx]
 
 	// Update stats
-	rm.stats.mu.Lock()
-	rm.stats.nodeFailures[oldIndex]++
-	rm.stats.nodeSwitches++
-	rm.stats.mu.Unlock()
+	r.stats.mu.Lock()
+	r.stats.nodeFailures[oldIndex]++
+	r.stats.nodeSwitches++
+	r.stats.mu.Unlock()
 
 	log.Warn().
 		Int("from_node", oldIndex).
-		Int("to_node", rm.currentIdx).
-		Int("total_switches", rm.stats.nodeSwitches).
-		Int("node_failures", rm.stats.nodeFailures[oldIndex]).
+		Int("to_node", r.currentIdx).
+		Int("total_switches", r.stats.nodeSwitches).
+		Int("node_failures", r.stats.nodeFailures[oldIndex]).
 		Msg("Switching to next RPC node")
 
 	return &newNode
 }
 
-func (rm *RPCManager) GetStats() (int, map[int]int) {
-	rm.stats.mu.RLock()
-	defer rm.stats.mu.RUnlock()
+func (r *RPCManager) GetStats() (int, map[int]int) {
+	r.stats.mu.RLock()
+	defer r.stats.mu.RUnlock()
 
 	// Create a copy of the stats to return
 	failuresCopy := make(map[int]int)
-	for k, v := range rm.stats.nodeFailures {
+	for k, v := range r.stats.nodeFailures {
 		failuresCopy[k] = v
 	}
 
-	return rm.stats.nodeSwitches, failuresCopy
+	return r.stats.nodeSwitches, failuresCopy
 }
 
 // SendDataWithNodeRetry attempts to send data to the chain, switching nodes if necessary

--- a/usecase/rpc_manager.go
+++ b/usecase/rpc_manager.go
@@ -60,14 +60,15 @@ func NewRPCManager(userConfig lib.UserConfig) (*RPCManager, error) {
 		return nil, fmt.Errorf("no RPC nodes provided")
 	}
 
-	validatedNodes, err := validateAndDeduplicateNodes(userConfig.Wallet.NodeRPCs)
+	// validate all urls are correct
+	err := validateNodes(userConfig.Wallet.NodeRPCs)
 	if err != nil {
 		return nil, err
 	}
 
 	// Load here the nodeconfigs
 	var nodes []lib.NodeConfig
-	for _, rpc := range validatedNodes {
+	for _, rpc := range userConfig.Wallet.NodeRPCs {
 		log.Info().Str("rpc", rpc).Msg("Initializing rpc")
 		nodeConfig, err := userConfig.GenerateNodeConfig(rpc)
 		if err != nil {
@@ -86,25 +87,15 @@ func NewRPCManager(userConfig lib.UserConfig) (*RPCManager, error) {
 	}, nil
 }
 
-func validateAndDeduplicateNodes(nodes []string) ([]string, error) {
-	seen := make(map[string]bool)
-	validated := make([]string, 0)
-
+func validateNodes(nodes []string) error {
 	for _, node := range nodes {
 		// Validate URL
 		_, err := url.ParseRequestURI(node)
 		if err != nil {
-			return nil, fmt.Errorf("invalid RPC URL %s: %w", node, err)
-		}
-
-		// Deduplicate
-		if !seen[node] {
-			seen[node] = true
-			validated = append(validated, node)
+			return fmt.Errorf("invalid RPC URL %s: %w", node, err)
 		}
 	}
-
-	return validated, nil
+	return nil
 }
 
 // SwitchToNextNode switches to the next node in the list.
@@ -159,12 +150,16 @@ func (r *RPCManager) SendDataWithNodeRetry(
 	totalNodes := len(r.nodes)
 
 	for attempts := 0; attempts < totalNodes; attempts++ {
-		log.Debug().Str("rpc", r.GetCurrentNode().Chain.Client.RPC.String()).Msg("Attempting with current node")
 		currentNode := r.GetCurrentNode()
-		currentIdx := r.currentIdx
+		currentIdx := r.GetCurrentIndex()
+		log.Debug().Str("rpc", r.GetCurrentNode().Wallet.NodeRPCs[currentIdx]).Msg("Attempting with current node")
 
 		// Skip if we've already tried this node
 		if triedNodes[currentIdx] {
+			log.Debug().Int("idx", currentIdx).
+				Str("rpc", r.GetCurrentNode().Wallet.NodeRPCs[currentIdx]).
+				Str("operation", operationName).
+				Msg("Already tried this node, switching to next")
 			r.SwitchToNextNode()
 			continue
 		}
@@ -182,6 +177,7 @@ func (r *RPCManager) SendDataWithNodeRetry(
 		if lib.IsErrorSwitchingNode(err) {
 			log.Warn().
 				Int("idx", currentIdx).
+				Str("rpc", r.GetCurrentNode().Wallet.NodeRPCs[currentIdx]).
 				Str("operation", operationName).
 				Msg("Switching to next node")
 			r.SwitchToNextNode()

--- a/usecase/rpc_manager.go
+++ b/usecase/rpc_manager.go
@@ -29,25 +29,6 @@ type RPCManager struct {
 	mu         sync.RWMutex
 }
 
-func (r *RPCManager) GetNodes() ([]lib.NodeConfig, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.nodes, nil
-}
-
-func (r *RPCManager) GetCurrentIndex() int {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.currentIdx
-}
-
-func (r *RPCManager) GetCurrentNode() *lib.NodeConfig {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return &r.nodes[r.currentIdx]
-}
-
-// newRPCManager is now private, used internally by InitRPCManager
 func NewRPCManager(userConfig lib.UserConfig) (*RPCManager, error) {
 	if len(userConfig.Wallet.NodeRPCs) == 0 {
 		return nil, fmt.Errorf("no RPC nodes provided")
@@ -78,15 +59,22 @@ func NewRPCManager(userConfig lib.UserConfig) (*RPCManager, error) {
 	}, nil
 }
 
-func validateNodes(nodes []string) error {
-	for _, node := range nodes {
-		// Validate URL
-		_, err := url.ParseRequestURI(node)
-		if err != nil {
-			return fmt.Errorf("invalid RPC URL %s: %w", node, err)
-		}
-	}
-	return nil
+func (r *RPCManager) GetNodes() ([]lib.NodeConfig, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.nodes, nil
+}
+
+func (r *RPCManager) GetCurrentIndex() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.currentIdx
+}
+
+func (r *RPCManager) GetCurrentNode() *lib.NodeConfig {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return &r.nodes[r.currentIdx]
 }
 
 // internal function, switches to a node assuming a lock has been acquired
@@ -185,4 +173,15 @@ func RunWithNodeRetry[T any](
 
 	return zeroValue, errorsmod.Wrapf(ErrAllNodesExhausted,
 		"tried %d nodes during %s", totalNodes, operationName)
+}
+
+func validateNodes(nodes []string) error {
+	for _, node := range nodes {
+		// Validate URL
+		_, err := url.ParseRequestURI(node)
+		if err != nil {
+			return fmt.Errorf("invalid RPC URL %s: %w", node, err)
+		}
+	}
+	return nil
 }

--- a/usecase/rpc_manager.go
+++ b/usecase/rpc_manager.go
@@ -16,6 +16,7 @@ import (
 
 type RPCManagerInterface interface {
 	GetCurrentNode() *lib.NodeConfig
+	GetCurrentIndex() int
 	SwitchToNextNode() *lib.NodeConfig
 	GetStats() (int, map[int]int)
 	SendDataWithNodeRetry(ctx context.Context, msg sdk.Msg, timeoutHeight uint64, operationName string) (*cosmosclient.Response, error)
@@ -39,6 +40,18 @@ func (r *RPCManager) GetNodes() ([]lib.NodeConfig, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.nodes, nil
+}
+
+func (r *RPCManager) GetCurrentIndex() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.currentIdx
+}
+
+func (r *RPCManager) GetCurrentNode() *lib.NodeConfig {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return &r.nodes[r.currentIdx]
 }
 
 // newRPCManager is now private, used internally by InitRPCManager
@@ -94,13 +107,10 @@ func validateAndDeduplicateNodes(nodes []string) ([]string, error) {
 	return validated, nil
 }
 
-func (r *RPCManager) GetCurrentNode() *lib.NodeConfig {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return &r.nodes[r.currentIdx]
-}
-
+// SwitchToNextNode switches to the next node in the list.
+// Node change is persistent, so it will be used again in the next call
 func (r *RPCManager) SwitchToNextNode() *lib.NodeConfig {
+	log.Info().Msg("Switching to next RPC node")
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -145,21 +155,22 @@ func (r *RPCManager) SendDataWithNodeRetry(
 	operationName string,
 ) (*cosmosclient.Response, error) {
 	// Track which nodes we've tried
-	triedNodes := make(map[string]bool)
+	triedNodes := make(map[int]bool)
 	totalNodes := len(r.nodes)
 
 	for attempts := 0; attempts < totalNodes; attempts++ {
+		log.Debug().Str("rpc", r.GetCurrentNode().Chain.Client.RPC.String()).Msg("Attempting with current node")
 		currentNode := r.GetCurrentNode()
-		nodeKey := currentNode.Chain.Address
+		currentIdx := r.currentIdx
 
 		// Skip if we've already tried this node
-		if triedNodes[nodeKey] {
+		if triedNodes[currentIdx] {
 			r.SwitchToNextNode()
 			continue
 		}
 
 		// Mark this node as tried
-		triedNodes[nodeKey] = true
+		triedNodes[currentIdx] = true
 
 		// Attempt to send data using existing retry mechanism
 		res, err := currentNode.SendDataWithRetry(ctx, msg, operationName, timeoutHeight)
@@ -170,7 +181,7 @@ func (r *RPCManager) SendDataWithNodeRetry(
 		// If it's a node switching error, switch to next node and continue
 		if lib.IsErrorSwitchingNode(err) {
 			log.Warn().
-				Str("node", nodeKey).
+				Int("idx", currentIdx).
 				Str("operation", operationName).
 				Msg("Switching to next node")
 			r.SwitchToNextNode()
@@ -195,8 +206,8 @@ func RunWithNodeRetry[T any](
 ) (T, error) {
 	var zeroValue T
 
-	// Track which nodes we've tried
-	triedNodes := make(map[string]bool)
+	// Change to use indices instead of addresses
+	triedNodes := make(map[int]bool)
 	nodes, err := r.GetNodes()
 	if err != nil {
 		return zeroValue, errorsmod.Wrapf(err, "error getting nodes")
@@ -205,16 +216,16 @@ func RunWithNodeRetry[T any](
 
 	for attempts := 0; attempts < totalNodes; attempts++ {
 		currentNode := r.GetCurrentNode()
-		nodeKey := currentNode.Chain.Address
+		currentIdx := r.GetCurrentIndex() // We can use the attempt number as the index
 
 		// Skip if we've already tried this node
-		if triedNodes[nodeKey] {
+		if triedNodes[currentIdx] {
 			r.SwitchToNextNode()
 			continue
 		}
 
 		// Mark this node as tried
-		triedNodes[nodeKey] = true
+		triedNodes[currentIdx] = true
 
 		// Attempt operation on current node
 		result, err := operation(currentNode)
@@ -225,7 +236,7 @@ func RunWithNodeRetry[T any](
 		// If it's a node switching error, switch to next node and continue
 		if lib.IsErrorSwitchingNode(err) {
 			log.Warn().
-				Str("node", nodeKey).
+				Int("idx", currentIdx). // Changed from node address to index
 				Str("operation", operationName).
 				Msg("Switching to next node")
 			r.SwitchToNextNode()

--- a/usecase/rpc_manager.go
+++ b/usecase/rpc_manager.go
@@ -18,7 +18,7 @@ type RPCManagerInterface interface {
 	GetCurrentNode() *lib.NodeConfig
 	GetCurrentIndex() int
 	SwitchToNextNode() *lib.NodeConfig
-	GetStats() (int, map[int]int)
+	SwitchToNode(index int) *lib.NodeConfig
 	SendDataWithNodeRetry(ctx context.Context, msg sdk.Msg, timeoutHeight uint64, operationName string) (*cosmosclient.Response, error)
 	GetNodes() ([]lib.NodeConfig, error)
 }
@@ -27,13 +27,6 @@ type RPCManager struct {
 	nodes      []lib.NodeConfig
 	currentIdx int
 	mu         sync.RWMutex
-	stats      RPCStats
-}
-
-type RPCStats struct {
-	nodeFailures map[int]int
-	nodeSwitches int
-	mu           sync.RWMutex
 }
 
 func (r *RPCManager) GetNodes() ([]lib.NodeConfig, error) {
@@ -72,7 +65,8 @@ func NewRPCManager(userConfig lib.UserConfig) (*RPCManager, error) {
 		log.Info().Str("rpc", rpc).Msg("Initializing rpc")
 		nodeConfig, err := userConfig.GenerateNodeConfig(rpc)
 		if err != nil {
-			return nil, err
+			log.Error().Err(err).Str("rpc", rpc).Msg("Error generating node config, skipping RPC node")
+			continue
 		}
 		nodes = append(nodes, *nodeConfig)
 	}
@@ -80,9 +74,6 @@ func NewRPCManager(userConfig lib.UserConfig) (*RPCManager, error) {
 	return &RPCManager{ // nolint: exhaustruct
 		nodes:      nodes,
 		currentIdx: 0,
-		stats: RPCStats{ // nolint: exhaustruct
-			nodeFailures: make(map[int]int),
-		},
 		// no need to init mu
 	}, nil
 }
@@ -98,99 +89,45 @@ func validateNodes(nodes []string) error {
 	return nil
 }
 
+// internal function, switches to a node assuming a lock has been acquired
+func (r *RPCManager) switchToNodeLocked(index int) *lib.NodeConfig {
+	oldIndex := r.currentIdx
+	r.currentIdx = index
+
+	log.Debug().
+		Str("from", r.nodes[oldIndex].RPC).
+		Str("to", r.nodes[index].RPC).
+		Msg("Switch to next RPC node")
+
+	return &r.nodes[index]
+}
+
 // SwitchToNextNode switches to the next node in the list.
 // Node change is persistent, so it will be used again in the next call
 func (r *RPCManager) SwitchToNextNode() *lib.NodeConfig {
-	log.Info().Msg("Switching to next RPC node")
 	r.mu.Lock()
 	defer r.mu.Unlock()
-
-	oldIndex := r.currentIdx
-	r.currentIdx = (r.currentIdx + 1) % len(r.nodes)
-	newNode := r.nodes[r.currentIdx]
-
-	// Update stats
-	r.stats.mu.Lock()
-	r.stats.nodeFailures[oldIndex]++
-	r.stats.nodeSwitches++
-	r.stats.mu.Unlock()
-
-	log.Warn().
-		Int("from_node", oldIndex).
-		Int("to_node", r.currentIdx).
-		Int("total_switches", r.stats.nodeSwitches).
-		Int("node_failures", r.stats.nodeFailures[oldIndex]).
-		Msg("Switching to next RPC node")
-
-	return &newNode
+	// Get next node index, wrap around if necessary
+	nextNode := (r.currentIdx + 1) % len(r.nodes)
+	return r.switchToNodeLocked(nextNode)
 }
 
-func (r *RPCManager) GetStats() (int, map[int]int) {
-	r.stats.mu.RLock()
-	defer r.stats.mu.RUnlock()
-
-	// Create a copy of the stats to return
-	failuresCopy := make(map[int]int)
-	for k, v := range r.stats.nodeFailures {
-		failuresCopy[k] = v
-	}
-
-	return r.stats.nodeSwitches, failuresCopy
+// Switches to a specific node, acquiring a lock
+func (r *RPCManager) SwitchToNode(index int) *lib.NodeConfig {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.switchToNodeLocked(index)
 }
 
-// SendDataWithNodeRetry attempts to send data to the chain, switching nodes if necessary
 func (r *RPCManager) SendDataWithNodeRetry(
 	ctx context.Context,
 	msg sdk.Msg,
 	timeoutHeight uint64,
 	operationName string,
 ) (*cosmosclient.Response, error) {
-	// Track which nodes we've tried
-	triedNodes := make(map[int]bool)
-	totalNodes := len(r.nodes)
-
-	for attempts := 0; attempts < totalNodes; attempts++ {
-		currentNode := r.GetCurrentNode()
-		currentIdx := r.GetCurrentIndex()
-		log.Debug().Str("rpc", r.GetCurrentNode().Wallet.NodeRPCs[currentIdx]).Msg("Attempting with current node")
-
-		// Skip if we've already tried this node
-		if triedNodes[currentIdx] {
-			log.Debug().Int("idx", currentIdx).
-				Str("rpc", r.GetCurrentNode().Wallet.NodeRPCs[currentIdx]).
-				Str("operation", operationName).
-				Msg("Already tried this node, switching to next")
-			r.SwitchToNextNode()
-			continue
-		}
-
-		// Mark this node as tried
-		triedNodes[currentIdx] = true
-
-		// Attempt to send data using existing retry mechanism
-		res, err := currentNode.SendDataWithRetry(ctx, msg, operationName, timeoutHeight)
-		if err == nil {
-			return res, nil
-		}
-
-		// If it's a node switching error, switch to next node and continue
-		if lib.IsErrorSwitchingNode(err) {
-			log.Warn().
-				Int("idx", currentIdx).
-				Str("rpc", r.GetCurrentNode().Wallet.NodeRPCs[currentIdx]).
-				Str("operation", operationName).
-				Msg("Switching to next node")
-			r.SwitchToNextNode()
-			continue
-		}
-
-		// For any other error, return it immediately
-		return nil, errorsmod.Wrapf(err, "error during %s", operationName)
-	}
-
-	// If we've tried all nodes and none worked
-	return nil, errorsmod.Wrapf(ErrAllNodesExhausted,
-		"tried %d nodes during %s", totalNodes, operationName)
+	return RunWithNodeRetry(ctx, r, func(node *lib.NodeConfig) (*cosmosclient.Response, error) {
+		return node.SendDataWithRetry(ctx, msg, operationName, timeoutHeight)
+	}, operationName)
 }
 
 // RunWithNodeRetry executes an operation that returns (T, error) on nodes until success or all nodes are exhausted
@@ -202,13 +139,14 @@ func RunWithNodeRetry[T any](
 ) (T, error) {
 	var zeroValue T
 
-	// Change to use indices instead of addresses
 	triedNodes := make(map[int]bool)
 	nodes, err := r.GetNodes()
 	if err != nil {
 		return zeroValue, errorsmod.Wrapf(err, "error getting nodes")
 	}
 	totalNodes := len(nodes)
+	// Force change of initial node
+	r.SwitchToNextNode()
 
 	for attempts := 0; attempts < totalNodes; attempts++ {
 		currentNode := r.GetCurrentNode()
@@ -223,7 +161,7 @@ func RunWithNodeRetry[T any](
 		// Mark this node as tried
 		triedNodes[currentIdx] = true
 
-		// Attempt operation on current node
+		// Attempt operation on current node - if no error, return result
 		result, err := operation(currentNode)
 		if err == nil {
 			return result, nil
@@ -232,18 +170,19 @@ func RunWithNodeRetry[T any](
 		// If it's a node switching error, switch to next node and continue
 		if lib.IsErrorSwitchingNode(err) {
 			log.Warn().
+				Err(err).
+				Str("rpc", currentNode.RPC).
 				Int("idx", currentIdx). // Changed from node address to index
 				Str("operation", operationName).
-				Msg("Switching to next node")
+				Msg("Error - Switching to next node")
 			r.SwitchToNextNode()
 			continue
 		}
 
-		// For any other error, return it immediately
+		// For any other error, return it immediately without switching to next node
 		return zeroValue, errorsmod.Wrapf(err, "error during %s", operationName)
 	}
 
-	// If we've tried all nodes and none worked
 	return zeroValue, errorsmod.Wrapf(ErrAllNodesExhausted,
 		"tried %d nodes during %s", totalNodes, operationName)
 }

--- a/usecase/spawn_actor_processes.go
+++ b/usecase/spawn_actor_processes.go
@@ -48,12 +48,20 @@ type ActorProcessParams[T lib.TopicActor] struct {
 
 // Spawns the actor processes and any associated non-essential routines
 func (suite *UseCaseSuite) Spawn(ctx context.Context) {
-	if suite.Node.Wallet.GasPrices == lib.AutoGasPrices {
+	if suite.RPCManager.GetCurrentNode().Wallet.GasPrices == lib.AutoGasPrices {
 		log.Info().Msg("auto gas prices. Updating fee price routine: starting.")
-		price, err := WithTimeoutResult(ctx, time.Duration(suite.Node.Wallet.TimeoutRPCSecondsQuery)*time.Second,
+		price, err := WithTimeoutResult(ctx, time.Duration(suite.RPCManager.GetCurrentNode().Wallet.TimeoutRPCSecondsQuery)*time.Second,
 			func(ctx context.Context) (float64, error) {
-				return suite.Node.GetBaseFee(ctx)
+				return RunWithNodeRetry(
+					ctx,
+					suite.RPCManager,
+					func(node *lib.NodeConfig) (float64, error) {
+						return node.GetBaseFee(ctx)
+					},
+					"get base fee",
+				)
 			})
+
 		if err != nil {
 			log.Error().Err(err).Msg("Error updating gas prices in auto mode - RPC availability issue?")
 			return
@@ -62,7 +70,7 @@ func (suite *UseCaseSuite) Spawn(ctx context.Context) {
 		// After intialization, start auto-update routine
 		go suite.UpdateGasPriceRoutine(ctx)
 	} else {
-		price, err := strconv.ParseFloat(suite.Node.Wallet.GasPrices, 64)
+		price, err := strconv.ParseFloat(suite.RPCManager.GetCurrentNode().Wallet.GasPrices, 64)
 		if err != nil {
 			log.Error().Err(err).Msg("Invalid gas prices format")
 			return
@@ -77,7 +85,7 @@ func (suite *UseCaseSuite) Spawn(ctx context.Context) {
 
 	// Run worker process per topic
 	alreadyStartedWorkerForTopic := make(map[emissionstypes.TopicId]bool)
-	for _, worker := range suite.Node.Worker {
+	for _, worker := range suite.RPCManager.GetCurrentNode().Worker {
 		if _, ok := alreadyStartedWorkerForTopic[worker.TopicId]; ok {
 			log.Warn().Uint64("topicId", worker.TopicId).Msg("Worker already started for topicId")
 			continue
@@ -94,7 +102,7 @@ func (suite *UseCaseSuite) Spawn(ctx context.Context) {
 
 	// Run reputer process per topic
 	alreadyStartedReputerForTopic := make(map[emissionstypes.TopicId]bool)
-	for _, reputer := range suite.Node.Reputer {
+	for _, reputer := range suite.RPCManager.GetCurrentNode().Reputer {
 		if _, ok := alreadyStartedReputerForTopic[reputer.TopicId]; ok {
 			log.Warn().Uint64("topicId", reputer.TopicId).Msg("Reputer already started for topicId")
 			continue
@@ -122,9 +130,9 @@ func (suite *UseCaseSuite) Spawn(ctx context.Context) {
 // Returns the nonce height acted upon (the received one or the new one if any)
 func (suite *UseCaseSuite) processWorkerPayload(ctx context.Context, worker lib.WorkerConfig, latestNonceHeightActedUpon int64, timeoutHeight uint64) (int64, error) {
 	// Get latest nonce with RPC timeout
-	latestOpenWorkerNonce, err := WithTimeoutResult(ctx, time.Duration(suite.Node.Wallet.TimeoutRPCSecondsQuery)*time.Second,
+	latestOpenWorkerNonce, err := WithTimeoutResult(ctx, time.Duration(suite.RPCManager.GetCurrentNode().Wallet.TimeoutRPCSecondsQuery)*time.Second,
 		func(ctx context.Context) (*emissionstypes.Nonce, error) {
-			return suite.Node.GetLatestOpenWorkerNonceByTopicId(ctx, worker.TopicId)
+			return suite.RPCManager.GetCurrentNode().GetLatestOpenWorkerNonceByTopicId(ctx, worker.TopicId)
 		})
 
 	if err != nil {
@@ -134,9 +142,9 @@ func (suite *UseCaseSuite) processWorkerPayload(ctx context.Context, worker lib.
 
 	if latestOpenWorkerNonce.BlockHeight > latestNonceHeightActedUpon {
 		// Check whitelist with RPC timeout
-		isWhitelisted, err := WithTimeoutResult(ctx, time.Duration(suite.Node.Wallet.TimeoutRPCSecondsQuery)*time.Second,
+		isWhitelisted, err := WithTimeoutResult(ctx, time.Duration(suite.RPCManager.GetCurrentNode().Wallet.TimeoutRPCSecondsQuery)*time.Second,
 			func(ctx context.Context) (bool, error) {
-				return suite.Node.CanSubmitWorker(ctx, worker.TopicId, suite.Node.Wallet.Address)
+				return suite.RPCManager.GetCurrentNode().CanSubmitWorker(ctx, worker.TopicId, suite.RPCManager.GetCurrentNode().Wallet.Address)
 			})
 
 		if err != nil {
@@ -149,7 +157,7 @@ func (suite *UseCaseSuite) processWorkerPayload(ctx context.Context, worker lib.
 		}
 
 		// Build and commit payload with transaction timeout
-		err = WithTimeout(ctx, time.Duration(suite.Node.Wallet.TimeoutRPCSecondsTx)*time.Second,
+		err = WithTimeout(ctx, time.Duration(suite.RPCManager.GetCurrentNode().Wallet.TimeoutRPCSecondsTx)*time.Second,
 			func(ctx context.Context) error {
 				return suite.BuildCommitWorkerPayload(ctx, worker, latestOpenWorkerNonce, timeoutHeight)
 			})
@@ -174,23 +182,38 @@ func (suite *UseCaseSuite) processReputerPayload(ctx context.Context, reputer li
 	log := log.With().Uint64("topicId", reputer.TopicId).Str("actorType", "reputer").Logger()
 	log.Info().Msg("Processing reputer payload")
 	// Get nonce with RPC timeout
-	nonce, err := WithTimeoutResult(ctx, time.Duration(suite.Node.Wallet.TimeoutRPCSecondsQuery)*time.Second,
-		func(ctx context.Context) (*emissionstypes.Nonce, error) {
-			return suite.Node.GetOldestReputerNonceByTopicId(ctx, reputer.TopicId)
-		})
 
+	nonce, err := RunWithNodeRetry(
+		ctx,
+		suite.RPCManager,
+		func(node *lib.NodeConfig) (*emissionstypes.Nonce, error) {
+			return WithTimeoutResult(ctx,
+				time.Duration(suite.RPCManager.GetCurrentNode().Wallet.TimeoutRPCSecondsQuery)*time.Second,
+				func(ctx context.Context) (*emissionstypes.Nonce, error) {
+					return node.GetOldestReputerNonceByTopicId(ctx, reputer.TopicId)
+				})
+		},
+		"get oldest reputer nonce",
+	)
 	if err != nil {
 		log.Warn().Err(err).Msg("Error getting latest open reputer nonce on topic - node availability issue?")
 		return latestNonceHeightActedUpon, err
 	}
 
 	if nonce.BlockHeight > latestNonceHeightActedUpon {
-		// Check whitelist with RPC timeout
-		isWhitelisted, err := WithTimeoutResult(ctx, time.Duration(suite.Node.Wallet.TimeoutRPCSecondsQuery)*time.Second,
-			func(ctx context.Context) (bool, error) {
-				return suite.Node.CanSubmitReputer(ctx, reputer.TopicId, suite.Node.Wallet.Address)
-			})
-
+		// Check if reputer can submit
+		isWhitelisted, err := RunWithNodeRetry(
+			ctx,
+			suite.RPCManager,
+			func(node *lib.NodeConfig) (bool, error) {
+				return WithTimeoutResult(ctx,
+					time.Duration(suite.RPCManager.GetCurrentNode().Wallet.TimeoutRPCSecondsQuery)*time.Second,
+					func(ctx context.Context) (bool, error) {
+						return node.CanSubmitReputer(ctx, reputer.TopicId, node.Wallet.Address)
+					})
+			},
+			"check reputer whitelist",
+		)
 		if err != nil {
 			log.Error().Err(err).Msg("Failed to check if reputer is whitelisted")
 			return latestNonceHeightActedUpon, err
@@ -201,7 +224,7 @@ func (suite *UseCaseSuite) processReputerPayload(ctx context.Context, reputer li
 		}
 
 		// Build and commit payload with transaction timeout
-		err = WithTimeout(ctx, time.Duration(suite.Node.Wallet.TimeoutRPCSecondsTx)*time.Second,
+		err = WithTimeout(ctx, time.Duration(suite.RPCManager.GetCurrentNode().Wallet.TimeoutRPCSecondsTx)*time.Second,
 			func(ctx context.Context) error {
 				return suite.BuildCommitReputerPayload(ctx, reputer, nonce.BlockHeight, timeoutHeight)
 			})
@@ -251,14 +274,22 @@ func (suite *UseCaseSuite) runWorkerProcess(ctx context.Context, worker lib.Work
 	log.Info().Msg("Running worker process for topic")
 
 	// Handle registration
-	registered, err := WithTimeoutResult(ctx, time.Duration(suite.Node.Wallet.TimeoutRPCSecondsRegistration)*time.Second,
-		func(ctx context.Context) (bool, error) {
-			return suite.Node.RegisterWorkerIdempotently(ctx, worker)
-		})
+	registered, err := RunWithNodeRetry(
+		ctx,
+		suite.RPCManager,
+		func(node *lib.NodeConfig) (bool, error) {
+			return WithTimeoutResult(ctx, time.Duration(suite.RPCManager.GetCurrentNode().Wallet.TimeoutRPCSecondsRegistration)*time.Second,
+				func(ctx context.Context) (bool, error) {
+					return node.RegisterWorkerIdempotently(ctx, worker)
+				})
+		},
+		"RegisterWorkerIdempotently",
+	)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to register worker for topic, exiting")
+		log.Fatal().Err(err).Msg("Failed to register for topic, exiting")
 		return
 	}
+
 	if !registered {
 		log.Error().Msg("Failed to register worker for topic, exiting")
 		return
@@ -272,20 +303,37 @@ func (suite *UseCaseSuite) runWorkerProcess(ctx context.Context, worker lib.Work
 		return
 	}
 
+	getNonce := func(ctx context.Context, topicId emissionstypes.TopicId) (*emissionstypes.Nonce, error) {
+		return RunWithNodeRetry(
+			ctx,
+			suite.RPCManager,
+			func(node *lib.NodeConfig) (*emissionstypes.Nonce, error) {
+				return node.GetLatestOpenWorkerNonceByTopicId(ctx, topicId)
+			},
+			"get latest open worker nonce",
+		)
+	}
 	params := ActorProcessParams[lib.WorkerConfig]{
 		Config:                 worker,
 		ProcessPayload:         suite.processWorkerPayload,
-		GetNonce:               suite.Node.GetLatestOpenWorkerNonceByTopicId,
+		GetNonce:               getNonce,
 		NearWindowLength:       topicInfo.WorkerSubmissionWindow, // Use worker window to determine "nearness"
 		SubmissionWindowLength: topicInfo.WorkerSubmissionWindow, // Use worker window for actual submission window
 		ActorType:              "worker",
 	}
 
 	// Check if worker is isWhitelisted
-	isWhitelisted, err := WithTimeoutResult(ctx, time.Duration(suite.Node.Wallet.TimeoutRPCSecondsQuery)*time.Second,
-		func(ctx context.Context) (bool, error) {
-			return suite.Node.CanSubmitWorker(ctx, worker.TopicId, suite.Node.Wallet.Address)
-		})
+	isWhitelisted, err := RunWithNodeRetry(
+		ctx,
+		suite.RPCManager,
+		func(node *lib.NodeConfig) (bool, error) {
+			return WithTimeoutResult(ctx, time.Duration(suite.RPCManager.GetCurrentNode().Wallet.TimeoutRPCSecondsQuery)*time.Second,
+				func(ctx context.Context) (bool, error) {
+					return node.CanSubmitWorker(ctx, worker.TopicId, node.Wallet.Address)
+				})
+		},
+		"check worker whitelist",
+	)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to check if worker is whitelisted")
 		return
@@ -306,18 +354,24 @@ func (suite *UseCaseSuite) runReputerProcess(ctx context.Context, reputer lib.Re
 	log.Debug().Msg("Running reputer process for topic")
 
 	// Handle registration and staking
-	registeredAndStaked, err := WithTimeoutResult(ctx, time.Duration(suite.Node.Wallet.TimeoutRPCSecondsRegistration)*time.Second,
-		func(ctx context.Context) (bool, error) {
-			return suite.Node.RegisterAndStakeReputerIdempotently(ctx, reputer)
-		})
+	registeredAndStaked, err := RunWithNodeRetry(
+		ctx,
+		suite.RPCManager,
+		func(node *lib.NodeConfig) (bool, error) {
+			return WithTimeoutResult(ctx,
+				time.Duration(suite.RPCManager.GetCurrentNode().Wallet.TimeoutRPCSecondsRegistration)*time.Second,
+				func(ctx context.Context) (bool, error) {
+					return node.RegisterAndStakeReputerIdempotently(ctx, reputer)
+				})
+		},
+		"RegisterAndStakeReputerIdempotently",
+	)
 	if err != nil {
-		log.Error().
-			Err(err).
-			Msg("Reputer registration failed")
+		log.Fatal().Msg("Failed to register or sufficiently stake for topic")
 		return
 	}
 	if !registeredAndStaked {
-		log.Error().Msg("Failed to register or sufficiently stake reputer for topic")
+		log.Error().Msg("Failed to register or sufficiently stake for topic")
 		return
 	}
 	log.Debug().Msg("Reputer registered and staked")
@@ -329,20 +383,38 @@ func (suite *UseCaseSuite) runReputerProcess(ctx context.Context, reputer lib.Re
 		return
 	}
 
+	getNonce := func(ctx context.Context, topicId emissionstypes.TopicId) (*emissionstypes.Nonce, error) {
+		return RunWithNodeRetry(
+			ctx,
+			suite.RPCManager,
+			func(node *lib.NodeConfig) (*emissionstypes.Nonce, error) {
+				return node.GetOldestReputerNonceByTopicId(ctx, topicId)
+			},
+			"get oldest reputer nonce",
+		)
+	}
 	params := ActorProcessParams[lib.ReputerConfig]{
 		Config:                 reputer,
 		ProcessPayload:         suite.processReputerPayload,
-		GetNonce:               suite.Node.GetOldestReputerNonceByTopicId,
+		GetNonce:               getNonce,
 		NearWindowLength:       topicInfo.WorkerSubmissionWindow, // Use worker window to determine "nearness"
 		SubmissionWindowLength: topicInfo.EpochLength,            // Use epoch length for actual submission window
 		ActorType:              "reputer",
 	}
 
 	// Check if reputer is isWhitelisted
-	isWhitelisted, err := WithTimeoutResult(ctx, time.Duration(suite.Node.Wallet.TimeoutRPCSecondsQuery)*time.Second,
-		func(ctx context.Context) (bool, error) {
-			return suite.Node.CanSubmitReputer(ctx, reputer.TopicId, suite.Node.Wallet.Address)
-		})
+	isWhitelisted, err := RunWithNodeRetry(
+		ctx,
+		suite.RPCManager,
+		func(node *lib.NodeConfig) (bool, error) {
+			return WithTimeoutResult(ctx,
+				time.Duration(suite.RPCManager.GetCurrentNode().Wallet.TimeoutRPCSecondsQuery)*time.Second,
+				func(ctx context.Context) (bool, error) {
+					return node.CanSubmitReputer(ctx, reputer.TopicId, node.Wallet.Address)
+				})
+		},
+		"check reputer whitelist",
+	)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to check if reputer is whitelisted")
 		return
@@ -379,10 +451,11 @@ func runActorProcess[T lib.TopicActor](ctx context.Context, suite *UseCaseSuite,
 	for {
 		log.Trace().Msg("Start iteration, querying latest block")
 		// Query the latest block
-		status, err := WithTimeoutResult(ctx, time.Duration(suite.Node.Wallet.TimeoutRPCSecondsQuery)*time.Second,
+		status, err := WithTimeoutResult(ctx, time.Duration(suite.RPCManager.GetCurrentNode().Wallet.TimeoutRPCSecondsQuery)*time.Second,
 			func(ctx context.Context) (*ctypes.ResultStatus, error) {
-				return suite.Node.Chain.Client.Status(ctx)
+				return suite.RPCManager.GetCurrentNode().Chain.Client.Status(ctx)
 			})
+
 		if err != nil {
 			log.Error().Err(err).Msg("Failed to get status")
 			if lib.DoneOrWait(ctx, WAIT_TIME_STATUS_CHECKS) {
@@ -416,7 +489,7 @@ func runActorProcess[T lib.TopicActor](ctx context.Context, suite *UseCaseSuite,
 			// Wait for an epochLength with a correction factor, it will self-adjust from there
 			waitingTimeInSeconds, err := calculateTimeDistanceInSeconds(
 				epochLength,
-				suite.Node.Wallet.BlockDurationEstimated,
+				suite.RPCManager.GetCurrentNode().Wallet.BlockDurationEstimated,
 				NEW_TOPIC_CORRECTION_FACTOR,
 			)
 			if err != nil {
@@ -462,8 +535,8 @@ func runActorProcess[T lib.TopicActor](ctx context.Context, suite *UseCaseSuite,
 
 			waitingTimeInSeconds, err = calculateTimeDistanceInSeconds(
 				distanceUntilNextEpoch,
-				suite.Node.Wallet.BlockDurationEstimated,
-				suite.Node.Wallet.WindowCorrectionFactor,
+				suite.RPCManager.GetCurrentNode().Wallet.BlockDurationEstimated,
+				suite.RPCManager.GetCurrentNode().Wallet.WindowCorrectionFactor,
 			)
 			if err != nil {
 				log.Error().Err(err).Msg("Error calculating time distance to next epoch after sending tx")
@@ -479,7 +552,7 @@ func runActorProcess[T lib.TopicActor](ctx context.Context, suite *UseCaseSuite,
 			// Inconsistent topic data, wait until the next epoch
 			waitingTimeInSeconds, err = calculateTimeDistanceInSeconds(
 				epochLength,
-				suite.Node.Wallet.BlockDurationEstimated,
+				suite.RPCManager.GetCurrentNode().Wallet.BlockDurationEstimated,
 				NEARNESS_CORRECTION_FACTOR,
 			)
 			if err != nil {
@@ -500,7 +573,7 @@ func runActorProcess[T lib.TopicActor](ctx context.Context, suite *UseCaseSuite,
 				closeBlockDistance := distanceUntilNextEpoch + offset
 				waitingTimeInSeconds, err = calculateTimeDistanceInSeconds(
 					closeBlockDistance,
-					suite.Node.Wallet.BlockDurationEstimated,
+					suite.RPCManager.GetCurrentNode().Wallet.BlockDurationEstimated,
 					NEARNESS_CORRECTION_FACTOR,
 				)
 				if err != nil {
@@ -519,8 +592,8 @@ func runActorProcess[T lib.TopicActor](ctx context.Context, suite *UseCaseSuite,
 				// Far distance, bigger waits until the submission window opens
 				waitingTimeInSeconds, err = calculateTimeDistanceInSeconds(
 					distanceUntilNextEpoch,
-					suite.Node.Wallet.BlockDurationEstimated,
-					suite.Node.Wallet.WindowCorrectionFactor,
+					suite.RPCManager.GetCurrentNode().Wallet.BlockDurationEstimated,
+					suite.RPCManager.GetCurrentNode().Wallet.WindowCorrectionFactor,
 				)
 				if err != nil {
 					log.Error().Err(err).Msg("Error calculating far distance to epochLength")
@@ -547,9 +620,10 @@ func queryTopicInfo[T lib.TopicActor](
 	suite *UseCaseSuite,
 	config T,
 ) (*emissionstypes.Topic, error) {
-	topicInfo, err := WithTimeoutResult(ctx, time.Duration(suite.Node.Wallet.TimeoutRPCSecondsQuery)*time.Second,
+	topicInfo, err := WithTimeoutResult(ctx,
+		time.Duration(suite.RPCManager.GetCurrentNode().Wallet.TimeoutRPCSecondsQuery)*time.Second,
 		func(ctx context.Context) (*emissionstypes.Topic, error) {
-			return suite.Node.GetTopicInfo(ctx, config.GetTopicId())
+			return suite.RPCManager.GetCurrentNode().GetTopicInfo(ctx, config.GetTopicId())
 		})
 	if err != nil {
 		return nil, errorsmod.Wrapf(err, "failed to get topic info")

--- a/usecase/spawn_actor_processes.go
+++ b/usecase/spawn_actor_processes.go
@@ -525,8 +525,6 @@ func runActorProcess[T lib.TopicActor](ctx context.Context, suite *UseCaseSuite,
 			distanceUntilNextEpoch := epochEnd - currentBlockHeight
 			if distanceUntilNextEpoch < 0 {
 				log.Warn().
-					Uint64("topicId", params.Config.GetTopicId()).
-					Str("actorType", params.ActorType).
 					Int64("distanceUntilNextEpoch", distanceUntilNextEpoch).
 					Int64("submissionWindowLength", params.SubmissionWindowLength).
 					Msg("Distance until next epoch is less than 0, setting to submissionWindowLength")

--- a/usecase/usecase_suite.go
+++ b/usecase/usecase_suite.go
@@ -5,8 +5,9 @@ import (
 )
 
 type UseCaseSuite struct {
-	Node    lib.NodeConfig
-	Metrics lib.Metrics
+	UserConfig lib.UserConfig
+	RPCManager RPCManagerInterface
+	Metrics    lib.Metrics
 }
 
 // Static method to create a new UseCaseSuite
@@ -15,11 +16,10 @@ func NewUseCaseSuite(userConfig lib.UserConfig) (*UseCaseSuite, error) {
 	if err != nil {
 		return nil, err
 	}
-	userConfig.CheckAndSetDefaults()
-	nodeConfig, err := userConfig.GenerateNodeConfig()
+
+	rpcManager, err := NewRPCManager(userConfig)
 	if err != nil {
 		return nil, err
 	}
-
-	return &UseCaseSuite{Node: *nodeConfig}, nil // nolint: exhaustruct
+	return &UseCaseSuite{UserConfig: userConfig, RPCManager: rpcManager}, nil // nolint: exhaustruct
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

* Creation of a RPCManager that controls the rpc endpoints.
* An RPC (client) is defined by a `NodeConfig`. The RPCManager holds a number of NodeConfigs, preconfigured. 
* Initialization, parameterisation of calls for  
* Compliant with current separation of responsibilities, `usecase` keeps node management (before initialised and never changed; now integrated as an RPCManager), while client-internal operations fall under `lib` (ie `NodeConfig`-based operations). 
* Definition of situations where a switch of node is required. For now, `error 429` and +`Mempool is full`, maybe to be expanded.
* RPCManager as an interface with its testing mock

Also: 
* custom errors and error refactorization
* fix whitelist extra check
* improve checking gas routine 


## Link(s) to Ticket(s) or Issue(s) resolved by this PR

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. -- being tested against chain
- [x] If documented, please describe where. If not, describe why docs are not needed. -- Added section in README
- [x] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo

* testing with several workers under load, and adding unit testing.
* review current usage processes esp on registration where several calls are made, etc. 
* potentially more refactors 