### PR TITLE
Fix Typos in GolangCI Configuration and API Adapter Comments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,7 +57,7 @@ linters-settings:
   gosec:
     config:
       G101:
-        pattern: "(?i)passwd|pass|password|pwd|secret|private_key|token|pw|apiKey|bearer|cred|mneumonic|seed|seedphrase|entropy"
+        pattern: "(?i)passwd|pass|password|pwd|secret|private_key|token|pw|apiKey|bearer|cred|mnemonic|seed|seedphrase|entropy"
         ignore_entropy: false
         # Maximum allowed entropy of the string.
         entropy_threshold: "80.0"

--- a/adapter/api/apiadapter/main.go
+++ b/adapter/api/apiadapter/main.go
@@ -30,7 +30,7 @@ func replacePlaceholders(urlTemplate string, params map[string]string) string {
 	return urlTemplate
 }
 
-// Replace placeholders and also the blockheheight
+// Replace placeholders and also the blockheight
 func replaceExtendedPlaceholders(urlTemplate string, params map[string]string, blockHeight int64, topicId uint64) string {
 	// Create a map of default parameters
 	blockHeightAsString := strconv.FormatInt(blockHeight, 10)


### PR DESCRIPTION
## Description

This pull request addresses two minor typos:

1. **.golangci.yml:**
   - **Change:** Corrected the typo in the regex pattern used by the gosec linter.
   - **Before:** `"mneumonic"`
   - **After:**  `"mnemonic"`
   - **Impact:** Ensures that the pattern accurately detects sensitive information.

2. **adapter/api/apiadapter/main.go:**
   - **Change:** Fixed a typo in a code comment.
   - **Before:** "Replace placeholders and also the blockheheight"
   - **After:**  "Replace placeholders and also the blockheight"
   - **Impact:** Improves the clarity and correctness of the comment.

## Commit Details

- **Commit:** `typo main.go …` by gap-editor (Verified, ID: `7c9457d`)
- **Commit:** `typo golangci.yml …` by gap-editor (Verified, ID: `9bb3dfe`)

## Files Changed

- `.golangci.yml` (1 addition, 1 deletion)
- `adapter/api/apiadapter/main.go` (1 addition, 1 deletion)

---

Please review the changes and merge if everything looks good. Thank you!
