### PR TITLE
Truth container now accepts a timestamp instead of block height

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ These below are excerpts of the configuration (with some parts omitted for brevi
         "lossFunctionEntrypointName": "apiAdapter",
         "minStake": "100000000",
         "groundTruthParameters": {
-          "GroundTruthEndpoint": "http://localhost:8888/gt/{Token}/{BlockHeight}",
+          "GroundTruthEndpoint": "http://localhost:8888/gt/{Token}/{BlockTime}",
           "Token": "ETHUSD"
         },
         "lossFunctionParameters": {
@@ -290,7 +290,7 @@ These below are excerpts of the configuration (with some parts omitted for brevi
         "lossFunctionEntrypointName": "apiAdapter",
         "minStake": "100000000",
         "groundTruthParameters": {
-          "GroundTruthEndpoint": "http://localhost:8888/gt/{Token}/{BlockHeight}",
+          "GroundTruthEndpoint": "http://localhost:8888/gt/{Token}/{BlockTime}",
           "Token": "ETHUSD"
         },
         "lossFunctionParameters": {

--- a/adapter/api/apiadapter/README.md
+++ b/adapter/api/apiadapter/README.md
@@ -35,7 +35,7 @@ Reputer: []lib.ReputerConfig{
         "loopSeconds": 30,
         "minStake": 100000,
         "groundTruthParameters": {
-          "GroundTruthEndpoint": "http://localhost:8888/gt/{Token}/{BlockHeight}",
+          "GroundTruthEndpoint": "http://localhost:8888/gt/{Token}/{BlockTime}",
           "Token": "ETHUSD"
         },
         "lossFunctionParameters": {

--- a/adapter/api/apiadapter/main.go
+++ b/adapter/api/apiadapter/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	alloraMath "github.com/allora-network/allora-chain/math"
 	"github.com/rs/zerolog/log"
@@ -38,6 +39,19 @@ func replaceExtendedPlaceholders(urlTemplate string, params map[string]string, b
 	defaultParams := map[string]string{
 		"BlockHeight": blockHeightAsString,
 		"TopicId":     topicIdAsString,
+	}
+	urlTemplate = replacePlaceholders(urlTemplate, defaultParams)
+	urlTemplate = replacePlaceholders(urlTemplate, params)
+	return urlTemplate
+}
+
+func replaceExtendedPlaceholdersWithTime(urlTemplate string, params map[string]string, blockTime time.Time, topicId uint64) string {
+	blockTimeUnix := blockTime.Unix()
+	blockTimeAsString := strconv.FormatInt(blockTimeUnix, 10)
+	topicIdAsString := strconv.FormatUint(topicId, 10)
+	defaultParams := map[string]string{
+		"BlockTime": blockTimeAsString,
+		"TopicId":   topicIdAsString,
 	}
 	urlTemplate = replacePlaceholders(urlTemplate, defaultParams)
 	urlTemplate = replacePlaceholders(urlTemplate, params)
@@ -130,11 +144,11 @@ func (a *AlloraAdapter) CalcForecast(node lib.WorkerConfig, blockHeight int64) (
 	return nodeValues, nil
 }
 
-func (a *AlloraAdapter) GroundTruth(node lib.ReputerConfig, blockHeight int64) (lib.Truth, error) {
+func (a *AlloraAdapter) GroundTruth(node lib.ReputerConfig, blockTime time.Time) (lib.Truth, error) {
 	log := log.With().Str("actorType", "reputer").Uint64("topicId", node.TopicId).Logger()
 
 	urlTemplate := node.GroundTruthParameters["GroundTruthEndpoint"]
-	url := replaceExtendedPlaceholders(urlTemplate, node.GroundTruthParameters, blockHeight, node.TopicId)
+	url := replaceExtendedPlaceholdersWithTime(urlTemplate, node.GroundTruthParameters, blockTime, node.TopicId)
 	log.Debug().Str("url", url).Msg("Ground truth endpoint")
 	groundTruth, err := requestEndpoint(url)
 	if err != nil {

--- a/adapter/api/source/main.py
+++ b/adapter/api/source/main.py
@@ -29,8 +29,8 @@ def get_forecast():
     return jsonify([nv.__dict__ for nv in node_values])
 
 
-@app.route('/truth/<token>/<blockheight>', methods=['GET'])
-def get_truth(token, blockheight):
+@app.route('/truth/<token>/<blockTime>', methods=['GET'])
+def get_truth(token, blockTime):
     random_float = str(random.uniform(0.0, 100.0))
     return random_float
 

--- a/config.example.json
+++ b/config.example.json
@@ -37,7 +37,7 @@
         "lossFunctionEntrypointName": "apiAdapter",
         "minStake": 100000000,
         "groundTruthParameters": {
-          "GroundTruthEndpoint": "http://localhost:8888/gt/{Token}/{BlockHeight}",
+          "GroundTruthEndpoint": "http://localhost:8888/gt/{Token}/{BlockTime}",
           "Token": "ETHUSD"
         },
         "lossFunctionParameters": {

--- a/lib/domain_entrypoint.go
+++ b/lib/domain_entrypoint.go
@@ -1,12 +1,14 @@
 package lib
 
+import "time"
+
 type Truth = string
 
 type AlloraAdapter interface {
 	Name() string
 	CalcInference(WorkerConfig, int64) (string, error)
 	CalcForecast(WorkerConfig, int64) ([]NodeValue, error)
-	GroundTruth(ReputerConfig, int64) (Truth, error)
+	GroundTruth(ReputerConfig, time.Time) (Truth, error)
 	LossFunction(ReputerConfig, string, string, map[string]string) (string, error)
 	IsLossFunctionNeverNegative(ReputerConfig, map[string]string) (bool, error)
 	CanInfer() bool

--- a/lib/repo_query_block.go
+++ b/lib/repo_query_block.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"context"
+	"time"
 
 	emissionstypes "github.com/allora-network/allora-chain/x/emissions/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
@@ -27,4 +28,12 @@ func (node *NodeConfig) GetReputerValuesAtBlock(ctx context.Context, topicId emi
 	}
 
 	return resp.NetworkInferences, nil
+}
+
+func (node *NodeConfig) GetBlockTime(ctx context.Context, nonce BlockHeight) (time.Time, error) {
+	header, err := node.Chain.Client.RPC.Header(ctx, &nonce)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return header.Header.Time, nil
 }

--- a/usecase/build_commit_reputer_payload.go
+++ b/usecase/build_commit_reputer_payload.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	errorsmod "cosmossdk.io/errors"
 	alloraMath "github.com/allora-network/allora-chain/math"
@@ -38,7 +39,19 @@ func (suite *UseCaseSuite) BuildCommitReputerPayload(ctx context.Context, repute
 	}
 	valueBundle.Reputer = suite.RPCManager.GetCurrentNode().Wallet.Address
 
-	sourceTruth, err := reputer.GroundTruthEntrypoint.GroundTruth(reputer, nonce)
+	blockTime, err := RunWithNodeRetry(
+		ctx,
+		suite.RPCManager,
+		func(node *lib.NodeConfig) (time.Time, error) {
+			return node.GetBlockTime(ctx, nonce)
+		},
+		"get block time",
+	)
+	if err != nil {
+		return errorsmod.Wrapf(err, "error getting block time, topicId: %d, blockHeight: %d", reputer.TopicId, nonce)
+	}
+
+	sourceTruth, err := reputer.GroundTruthEntrypoint.GroundTruth(reputer, blockTime)
 	if err != nil {
 		return errorsmod.Wrapf(err, "error getting source truth from reputer, topicId: %d, blockHeight: %d", reputer.TopicId, nonce)
 	}

--- a/usecase/mock_allora_adapter_test.go
+++ b/usecase/mock_allora_adapter_test.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"allora_offchain_node/lib"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 )
@@ -25,8 +26,8 @@ func (m *MockAlloraAdapter) CalcForecast(config lib.WorkerConfig, timestamp int6
 	return args.Get(0).([]lib.NodeValue), args.Error(1) // nolint: forcetypeassert
 }
 
-func (m *MockAlloraAdapter) GroundTruth(config lib.ReputerConfig, timestamp int64) (lib.Truth, error) {
-	args := m.Called(config, timestamp)
+func (m *MockAlloraAdapter) GroundTruth(config lib.ReputerConfig, blockTime time.Time) (lib.Truth, error) {
+	args := m.Called(config, blockTime)
 	return args.Get(0).(lib.Truth), args.Error(1) // nolint: forcetypeassert
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

Truth container needs the block time and, to get that, it needs to call the Allora RPC. To remove that dependency, we will call the container with the block time as a new parameter.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

https://linear.app/alloralabs/issue/ENGN-3381/truth-container-should-accept-a-timestamp-and-not-directly-depend-on

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [x] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?

## Still Left Todo

*Fill this out if this is a Draft PR so others can help.*
