### PR TITLE
Diego/engn 3612 reconnection infinite reconnection attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [#119](https://github.com/allora-network/allora-offchain-node/pull/119) GRPC client reconnection logic
+
 ### Removed
 
 ### Fixed

--- a/lib/grpcclient/README.md
+++ b/lib/grpcclient/README.md
@@ -1,0 +1,12 @@
+# GRPC Client
+
+This package provides a gRPC client implementation that handles connection management, monitoring, and reconnection logic.
+
+## Features
+
+- Automatic connection monitoring and reconnection
+- Connection state tracking and logging
+- Graceful shutdown with context cancellation
+- Metrics collection for connection health
+
+

--- a/lib/grpcclient/grpc_connection.go
+++ b/lib/grpcclient/grpc_connection.go
@@ -2,9 +2,10 @@ package grpcclient
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/big"
 	"time"
 
 	"allora_offchain_node/metrics"
@@ -39,8 +40,17 @@ func (bc *backoffConfig) nextBackoff(current time.Duration) time.Duration {
 
 	// Apply jitter: randomly subtract up to jitterFrac of the duration
 	jitterRange := float64(next) * bc.jitterFrac
-	jitter := time.Duration(rand.Float64() * jitterRange)
 
+	// Generate cryptographically secure random number between 0 and jitterRange
+	maxJitter := big.NewInt(int64(jitterRange))
+	randomBig, err := rand.Int(rand.Reader, maxJitter)
+	if err != nil {
+		// If we fail to generate random jitter, just return the next backoff without jitter
+		log.Warn().Err(err).Msg("Failed to generate jitter, continuing without it")
+		return next
+	}
+
+	jitter := time.Duration(randomBig.Int64())
 	return next - jitter
 }
 

--- a/lib/grpcclient/grpc_connection.go
+++ b/lib/grpcclient/grpc_connection.go
@@ -17,75 +17,128 @@ import (
 	"google.golang.org/grpc/keepalive"
 )
 
+type backoffConfig struct {
+	initial    time.Duration
+	max        time.Duration
+	maxRetries int
+	jitterFrac float64 // fraction of the backoff to use for jitter
+}
+
+func newBackoffConfig() backoffConfig {
+	return backoffConfig{
+		initial:    1 * time.Second,
+		max:        30 * time.Second,
+		maxRetries: 5,
+		jitterFrac: 0.2, // 20% jitter
+	}
+}
+
+func (bc *backoffConfig) nextBackoff(current time.Duration) time.Duration {
+	// Calculate base backoff with exponential increase
+	next := time.Duration(math.Min(float64(current*2), float64(bc.max)))
+
+	// Apply jitter: randomly subtract up to jitterFrac of the duration
+	jitterRange := float64(next) * bc.jitterFrac
+	jitter := time.Duration(rand.Float64() * jitterRange)
+
+	return next - jitter
+}
+
 func monitorGRPCConnection(ctx context.Context, grpcConnection *grpc.ClientConn, grpcEndpoint string) {
+	if grpcConnection == nil {
+		log.Error().Msg("nil gRPC connection provided to monitor")
+		return
+	}
+
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
 
-	maxRetries := 5
+	bc := newBackoffConfig()
 	retryCount := 0
-	initialBackoff := 1 * time.Second
-	maxBackoff := 30 * time.Second
-	backoff := initialBackoff
+	backoff := bc.initial
 
 	for {
 		select {
 		case <-ctx.Done():
-			log.Info().Msg("Shutting down gRPC monitoring goroutine.")
+			log.Info().Msg("Shutting down gRPC monitoring goroutine")
 			return
 		case <-ticker.C:
 			state := grpcConnection.GetState()
-			if state == connectivity.TransientFailure || state == connectivity.Shutdown {
-				log.Warn().Msg("gRPC Connection lost, attempting to reconnect...")
 
-				// Force reconnection attempt
-				grpcConnection.ResetConnectBackoff()
-				grpcConnection.Connect()
-				if grpcConnection.GetState() != connectivity.Ready {
-					retryCount++
-					log.Warn().Int("retry", retryCount).
-						Dur("backoff", backoff).
-						Msg("Reconnection attempt failed")
-
-					if retryCount >= maxRetries {
-						log.Error().Msg("Max reconnection attempts reached, triggering shutdown")
-						return
-					}
-
-					// Exponential backoff with jitter
-					jitter := time.Duration(rand.Int63n(int64(backoff) / 2))
-					time.Sleep(backoff + jitter)
-					backoff = time.Duration(math.Min(float64(backoff*2), float64(maxBackoff)))
-				} else {
-					log.Info().Msg("gRPC connection restored")
-					metrics.GetMetrics().IncrementMetricsCounterWithLabels(metrics.GRPCConnectionLostCount, grpcEndpoint)
-					retryCount = 0           // Reset counter on success
-					backoff = initialBackoff // Reset backoff on success
-				}
+			// Only attempt reconnection if we're in a failed state
+			if state != connectivity.TransientFailure && state != connectivity.Shutdown {
+				continue
+			}
+			metrics.GetMetrics().IncrementMetricsCounterWithLabels(metrics.GRPCConnectionLostCount, grpcEndpoint)
+			log.Warn().Msg("gRPC Connection lost, attempting to reconnect...")
+			if err := attemptReconnection(ctx, grpcConnection, &retryCount, &backoff, bc, grpcEndpoint); err != nil {
+				return // Monitor shutdown due to max retries or context cancellation
 			}
 		}
 	}
 }
 
-// Initializes a gRPC client for the given endpoint
-func InitializeGRPCClient(ctx context.Context, grpcEndpoint string, insecureFlag bool) (grpcConnection *grpc.ClientConn, err error) {
-	var dialOptions []grpc.DialOption
+func attemptReconnection(
+	ctx context.Context,
+	conn *grpc.ClientConn,
+	retryCount *int,
+	backoff *time.Duration,
+	bc backoffConfig,
+	endpoint string,
+) error {
+	// Force reconnection attempt
+	conn.ResetConnectBackoff()
+	conn.Connect()
 
-	kaOpts := keepalive.ClientParameters{
-		Time:                10 * time.Second,
-		Timeout:             10 * time.Second,
-		PermitWithoutStream: true,
+	if conn.GetState() == connectivity.Ready {
+		log.Info().Msg("gRPC connection restored")
+		metrics.GetMetrics().IncrementMetricsCounterWithLabels(metrics.GRPCReconnectionCount, endpoint)
+		*retryCount = 0
+		*backoff = bc.initial
+		return nil
 	}
 
-	customCodec := &customCodec{}
-	dialOptions = append(dialOptions, grpc.WithKeepaliveParams(kaOpts))
-	dialOptions = append(dialOptions,
+	*retryCount++
+	log.Warn().
+		Int("retry", *retryCount).
+		Dur("backoff", *backoff).
+		Msg("Reconnection attempt failed")
+
+	if *retryCount >= bc.maxRetries {
+		metrics.GetMetrics().IncrementMetricsCounterWithLabels(metrics.GRPCConnectionPermanentFailure, endpoint)
+		log.Error().Msg("Max reconnection attempts reached, triggering shutdown")
+		return fmt.Errorf("max reconnection retries exceeded")
+	}
+
+	// Wait for backoff duration or context cancellation
+	timer := time.NewTimer(*backoff)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		*backoff = bc.nextBackoff(*backoff)
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("context cancelled during backoff: %w", ctx.Err())
+	}
+}
+
+// InitializeGRPCClient initializes a gRPC client for the given endpoint with proper connection monitoring
+func InitializeGRPCClient(ctx context.Context, grpcEndpoint string, insecureFlag bool) (*grpc.ClientConn, error) {
+	dialOptions := []grpc.DialOption{
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                10 * time.Second,
+			Timeout:             10 * time.Second,
+			PermitWithoutStream: true,
+		}),
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(8*1024*1024),
 			grpc.MaxCallSendMsgSize(8*1024*1024),
-			grpc.ForceCodec(customCodec),
+			grpc.ForceCodec(&customCodec{}),
 		),
-	)
+	}
 
+	// Configure transport security
 	if insecureFlag {
 		dialOptions = append(dialOptions, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
@@ -93,11 +146,13 @@ func InitializeGRPCClient(ctx context.Context, grpcEndpoint string, insecureFlag
 		dialOptions = append(dialOptions, grpc.WithTransportCredentials(creds))
 	}
 
-	// Add interceptor for logging if needed
-	// dialOptions = append(dialOptions, grpc.WithUnaryInterceptor(loggerHeaderInterceptor()))
-	log.Debug().Interface("dialOptions", dialOptions).Str("target", grpcEndpoint).Msg("Dial options")
+	log.Debug().
+		Interface("dialOptions", dialOptions).
+		Str("target", grpcEndpoint).
+		Msg("Initializing gRPC client with options")
+
 	log.Info().Msg("Creating new gRPC client")
-	grpcConnection, err = grpc.NewClient(
+	grpcConnection, err := grpc.NewClient(
 		grpcEndpoint,
 		dialOptions...,
 	)
@@ -105,7 +160,7 @@ func InitializeGRPCClient(ctx context.Context, grpcEndpoint string, insecureFlag
 		return nil, fmt.Errorf("failed to connect to %s: %w", grpcEndpoint, err)
 	}
 
-	// spin up goroutine for monitoring and reconnect purposes - TODO test and configure
+	// Start connection monitoring in a separate goroutine
 	go monitorGRPCConnection(ctx, grpcConnection, grpcEndpoint)
 
 	return grpcConnection, nil

--- a/lib/grpcclient/grpc_connection.go
+++ b/lib/grpcclient/grpc_connection.go
@@ -15,46 +15,38 @@ import (
 	"google.golang.org/grpc/keepalive"
 )
 
-// monitorGRPCConnection monitors the gRPC connection state and attempts to reconnect when needed.
-func monitorGRPCConnection(ctx context.Context, grpcConnnection *grpc.ClientConn, grpcEndpoint string) {
+func monitorGRPCConnection(ctx context.Context, grpcConnection *grpc.ClientConn, grpcEndpoint string) {
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
 
+	maxRetries := 5
+	retryCount := 0
+
 	for {
 		select {
-		case <-ctx.Done(): // Graceful shutdown
+		case <-ctx.Done():
 			log.Info().Msg("Shutting down gRPC monitoring goroutine.")
 			return
-
 		case <-ticker.C:
-			state := grpcConnnection.GetState()
+			state := grpcConnection.GetState()
 			if state == connectivity.TransientFailure || state == connectivity.Shutdown {
 				log.Warn().Msg("gRPC Connection lost, attempting to reconnect...")
 
-				// Exponential backoff for reconnection attempts
-				backoff := time.Second
-				maxBackoff := 30 * time.Second
+				// Force reconnection attempt
+				grpcConnection.ResetConnectBackoff()
+				grpcConnection.Connect()
+				if grpcConnection.GetState() != connectivity.Ready {
+					retryCount++
+					log.Warn().Int("retry", retryCount).Msg("Reconnection attempt failed")
 
-				for {
-					select {
-					case <-ctx.Done():
-						log.Info().Msg("Stopping reconnection attempts due to shutdown.")
+					if retryCount >= maxRetries {
+						log.Error().Msg("Max reconnection attempts reached, triggering shutdown")
 						return
-
-					default:
-						// Wait for a state change
-						if grpcConnnection.WaitForStateChange(ctx, state) {
-							log.Info().Msg("gRPC connection state changed, resuming normal operation.")
-							metrics.GetMetrics().IncrementMetricsCounterWithLabels(metrics.GRPCConnectionLostCount, grpcEndpoint)
-							break
-						}
-
-						// Increase backoff exponentially, up to maxBackoff
-						time.Sleep(backoff)
-						if backoff < maxBackoff {
-							backoff *= 2
-						}
 					}
+				} else {
+					log.Info().Msg("gRPC connection restored")
+					metrics.GetMetrics().IncrementMetricsCounterWithLabels(metrics.GRPCConnectionLostCount, grpcEndpoint)
+					retryCount = 0 // Reset counter on success
 				}
 			}
 		}

--- a/lib/grpcclient/grpc_connection.go
+++ b/lib/grpcclient/grpc_connection.go
@@ -3,6 +3,8 @@ package grpcclient
 import (
 	"context"
 	"fmt"
+	"math"
+	"math/rand"
 	"time"
 
 	"allora_offchain_node/metrics"
@@ -21,6 +23,9 @@ func monitorGRPCConnection(ctx context.Context, grpcConnection *grpc.ClientConn,
 
 	maxRetries := 5
 	retryCount := 0
+	initialBackoff := 1 * time.Second
+	maxBackoff := 30 * time.Second
+	backoff := initialBackoff
 
 	for {
 		select {
@@ -37,16 +42,24 @@ func monitorGRPCConnection(ctx context.Context, grpcConnection *grpc.ClientConn,
 				grpcConnection.Connect()
 				if grpcConnection.GetState() != connectivity.Ready {
 					retryCount++
-					log.Warn().Int("retry", retryCount).Msg("Reconnection attempt failed")
+					log.Warn().Int("retry", retryCount).
+						Dur("backoff", backoff).
+						Msg("Reconnection attempt failed")
 
 					if retryCount >= maxRetries {
 						log.Error().Msg("Max reconnection attempts reached, triggering shutdown")
 						return
 					}
+
+					// Exponential backoff with jitter
+					jitter := time.Duration(rand.Int63n(int64(backoff) / 2))
+					time.Sleep(backoff + jitter)
+					backoff = time.Duration(math.Min(float64(backoff*2), float64(maxBackoff)))
 				} else {
 					log.Info().Msg("gRPC connection restored")
 					metrics.GetMetrics().IncrementMetricsCounterWithLabels(metrics.GRPCConnectionLostCount, grpcEndpoint)
-					retryCount = 0 // Reset counter on success
+					retryCount = 0           // Reset counter on success
+					backoff = initialBackoff // Reset backoff on success
 				}
 			}
 		}

--- a/metrics/constant.go
+++ b/metrics/constant.go
@@ -6,17 +6,19 @@ var EndpointLabels = []string{"endpoint"}
 
 // metrics
 const (
-	InferenceRequestCount       string = "allora_worker_inference_request_count"
-	ForecastRequestCount        string = "allora_worker_forecast_request_count"
-	TruthRequestCount           string = "allora_reputer_truth_request_count"
-	WorkerDataBuildCount        string = "allora_worker_data_build_count"
-	ReputerDataBuildCount       string = "allora_reputer_data_build_count"
-	WorkerChainSubmissionCount  string = "allora_worker_chain_submission_count"
-	ReputerChainSubmissionCount string = "allora_reputer_chain_submission_count"
-	WorkerProcessFinishedCount  string = "allora_worker_process_finished_count"
-	ReputerProcessFinishedCount string = "allora_reputer_process_finished_count"
-	ApplicationFinishedCount    string = "allora_application_finished_count"
-	GRPCConnectionLostCount     string = "allora_grpc_connection_lost_count"
+	InferenceRequestCount          string = "allora_worker_inference_request_count"
+	ForecastRequestCount           string = "allora_worker_forecast_request_count"
+	TruthRequestCount              string = "allora_reputer_truth_request_count"
+	WorkerDataBuildCount           string = "allora_worker_data_build_count"
+	ReputerDataBuildCount          string = "allora_reputer_data_build_count"
+	WorkerChainSubmissionCount     string = "allora_worker_chain_submission_count"
+	ReputerChainSubmissionCount    string = "allora_reputer_chain_submission_count"
+	WorkerProcessFinishedCount     string = "allora_worker_process_finished_count"
+	ReputerProcessFinishedCount    string = "allora_reputer_process_finished_count"
+	ApplicationFinishedCount       string = "allora_application_finished_count"
+	GRPCConnectionLostCount        string = "allora_grpc_connection_lost_count"
+	GRPCReconnectionCount          string = "allora_grpc_reconnection_count"
+	GRPCConnectionPermanentFailure string = "allora_grpc_connection_permanent_failure"
 )
 
 // A struct that holds the name and help text for a prometheus counter
@@ -32,4 +34,6 @@ var CounterData = []MetricsCounter{
 	{ReputerProcessFinishedCount, "The total number of reputer processes finished", DefaultLabels},
 	{ApplicationFinishedCount, "The total number of application runs finished", DefaultLabels},
 	{GRPCConnectionLostCount, "The total number of times the GRPC connection is lost", EndpointLabels},
+	{GRPCReconnectionCount, "The total number of times the GRPC connection is successfully reconnected", EndpointLabels},
+	{GRPCConnectionPermanentFailure, "The total number of times the GRPC connection is lost", EndpointLabels},
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
* Fix reconnection scenario where an infinite reconnection loop would happen
* Adds exponential backoff with jitter as grpc reconnection mechanism

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. ✅ * Tested against local chain start/stop/start with internal reconnections, works fine now. Issue has been reproduced and now is fixed.
- [x] If documented, please describe where. If not, describe why docs are not needed. ✅ documented on its own README on the grpcclient package
- [x] Added to `Unreleased` section of `CHANGELOG.md`? 

