### PR TITLE
Fix early exit from registration, added param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+### Security
+
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
 ### Fixed
+
+* [124](https://github.com/allora-network/allora-offchain-node/pull/124) Fix early exit from registration
+
+### Removed
 
 ### Security
 
@@ -68,7 +81,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-### Fixed
 
 ### Security
 
@@ -88,10 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-### Fixed
-
 ### Security
-
 
 
 ## v0.9.1
@@ -105,8 +114,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#114](https://github.com/allora-network/allora-offchain-node/pull/114) Fix tx simulation(seqnum, gasAdjustment, err handling), validation, tests and minor refactor
 
 ### Removed
-
-### Fixed
 
 ### Security
 
@@ -124,7 +131,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-### Fixed
 
 ### Security
 
@@ -146,8 +152,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-### Fixed
-
 ### Security
 
 
@@ -162,8 +166,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Removed
-
-### Fixed
 
 ### Security
 

--- a/lib/domain_config.go
+++ b/lib/domain_config.go
@@ -23,6 +23,7 @@ const (
 	GasPriceUpdateIntervalMin          = 5
 	RetryDelayMin                      = 1
 	AccountSequenceRetryDelayMin       = 1
+	RegistrationWaitingBlocksMin       = 1
 )
 
 // Default values
@@ -41,6 +42,7 @@ const (
 	DefaultGasAdjustment                 float64 = 1.2
 	DefaultSimulateGasFromStart          bool    = false
 	DefaultGrpcInsecure                  bool    = false
+	DefaultRegistrationWaitingBlocks     int64   = 5
 )
 
 // Properties manually provided by the user as part of UserConfig
@@ -67,6 +69,7 @@ type WalletConfig struct {
 	LaunchRoutineDelay            int64                   // number of seconds to wait between starting a routine and the next one to avoid 429 errors
 	SubmitTx                      bool                    // useful for dev/testing. set to false to run in dry-run processes without committing to the chain
 	BlockDurationEstimated        float64                 // estimated average block duration in seconds
+	RegistrationWaitingBlocks     int64                   // number of blocks to wait for a registration to be included in a block
 	WindowCorrectionFactor        float64                 // correction factor for the time estimation, suggested range 0.7-0.9.
 	TimeoutRPCSecondsQuery        int64                   // timeout for rpc queries in seconds, including retries
 	TimeoutRPCSecondsTx           int64                   // timeout for rpc data send in seconds, including retries
@@ -201,6 +204,9 @@ func (c *UserConfig) CheckAndSetDefaults() {
 	if c.Wallet.GasAdjustment == 0 {
 		c.Wallet.GasAdjustment = DefaultGasAdjustment
 	}
+	if c.Wallet.RegistrationWaitingBlocks == 0 {
+		c.Wallet.RegistrationWaitingBlocks = DefaultRegistrationWaitingBlocks
+	}
 }
 
 // Check that each assigned entrypoint in the user config actually can be used
@@ -261,6 +267,9 @@ func (c *UserConfig) ValidateWalletConfig() error {
 	}
 	if c.Wallet.GasAdjustment <= 0 {
 		return fmt.Errorf("gas adjustment must be greater than 0: %f", c.Wallet.GasAdjustment)
+	}
+	if c.Wallet.RegistrationWaitingBlocks < RegistrationWaitingBlocksMin {
+		return fmt.Errorf("registration waiting blocks lower than the minimum: %d < %d", c.Wallet.RegistrationWaitingBlocks, RegistrationWaitingBlocksMin)
 	}
 	return nil
 }

--- a/usecase/repo_tx_registration.go
+++ b/usecase/repo_tx_registration.go
@@ -93,7 +93,7 @@ func (suite *UseCaseSuite) RegisterWorkerIdempotently(ctx context.Context, confi
 	}
 
 	// Give time for the tx to be included in a block
-	delay := int64(walletConfig.BlockDurationEstimated) * int64(walletConfig.RegistrationWaitingBlocks)
+	delay := int64(walletConfig.BlockDurationEstimated * float64(walletConfig.RegistrationWaitingBlocks))
 	log.Debug().Int64("delay", delay).Msg("Waiting to check registration status to be included in a block...")
 	if lib.DoneOrWait(ctx, delay) {
 		log.Error().Err(ctx.Err()).Str("rpc", queryNode.ServerAddress).Msg("Waiting to check registration status failed")
@@ -178,7 +178,7 @@ func (suite *UseCaseSuite) RegisterAndStakeReputerIdempotently(ctx context.Conte
 		}
 
 		// Give time for the tx to be included in a block
-		delay := int64(walletConfig.BlockDurationEstimated) * int64(walletConfig.RegistrationWaitingBlocks)
+		delay := int64(walletConfig.BlockDurationEstimated * float64(walletConfig.RegistrationWaitingBlocks))
 		log.Debug().Int64("delay", delay).Msg("Waiting to check registration status to be included in a block...")
 		if lib.DoneOrWait(ctx, delay) {
 			log.Error().Err(ctx.Err()).Str("rpc", queryNode.ServerAddress).Msg("Waiting to check registration status failed")
@@ -239,7 +239,7 @@ func (suite *UseCaseSuite) RegisterAndStakeReputerIdempotently(ctx context.Conte
 	}
 
 	// Give time for the tx to be included in a block
-	delay := int64(walletConfig.BlockDurationEstimated) * int64(walletConfig.RegistrationWaitingBlocks)
+	delay := int64(walletConfig.BlockDurationEstimated * float64(walletConfig.RegistrationWaitingBlocks))
 	log.Debug().Int64("delay", delay).Msg("Waiting to check stake status to be included in a block...")
 	if lib.DoneOrWait(ctx, delay) {
 		log.Error().Err(ctx.Err()).Str("rpc", queryNode.ServerAddress).Msg("Waiting to check stake status failed")

--- a/usecase/repo_tx_registration.go
+++ b/usecase/repo_tx_registration.go
@@ -93,8 +93,9 @@ func (suite *UseCaseSuite) RegisterWorkerIdempotently(ctx context.Context, confi
 	}
 
 	// Give time for the tx to be included in a block
-	log.Debug().Int64("delay", int64(walletConfig.BlockDurationEstimated)*2).Msg("Waiting to check registration status to be included in a block...")
-	if lib.DoneOrWait(ctx, int64(walletConfig.BlockDurationEstimated)*2) {
+	delay := int64(walletConfig.BlockDurationEstimated) * int64(walletConfig.RegistrationWaitingBlocks)
+	log.Debug().Int64("delay", delay).Msg("Waiting to check registration status to be included in a block...")
+	if lib.DoneOrWait(ctx, delay) {
 		log.Error().Err(ctx.Err()).Str("rpc", queryNode.ServerAddress).Msg("Waiting to check registration status failed")
 		return false, ctx.Err()
 	}
@@ -177,8 +178,9 @@ func (suite *UseCaseSuite) RegisterAndStakeReputerIdempotently(ctx context.Conte
 		}
 
 		// Give time for the tx to be included in a block
-		log.Debug().Int64("delay", int64(walletConfig.BlockDurationEstimated)*2).Msg("Waiting to check registration status to be included in a block...")
-		if lib.DoneOrWait(ctx, int64(walletConfig.BlockDurationEstimated)*2) {
+		delay := int64(walletConfig.BlockDurationEstimated) * int64(walletConfig.RegistrationWaitingBlocks)
+		log.Debug().Int64("delay", delay).Msg("Waiting to check registration status to be included in a block...")
+		if lib.DoneOrWait(ctx, delay) {
 			log.Error().Err(ctx.Err()).Str("rpc", queryNode.ServerAddress).Msg("Waiting to check registration status failed")
 			return false, ctx.Err()
 		}
@@ -237,8 +239,9 @@ func (suite *UseCaseSuite) RegisterAndStakeReputerIdempotently(ctx context.Conte
 	}
 
 	// Give time for the tx to be included in a block
-	log.Debug().Int64("delay", int64(walletConfig.BlockDurationEstimated)*2).Msg("Waiting to check stake status to be included in a block...")
-	if lib.DoneOrWait(ctx, int64(walletConfig.BlockDurationEstimated)*2) {
+	delay := int64(walletConfig.BlockDurationEstimated) * int64(walletConfig.RegistrationWaitingBlocks)
+	log.Debug().Int64("delay", delay).Msg("Waiting to check stake status to be included in a block...")
+	if lib.DoneOrWait(ctx, delay) {
 		log.Error().Err(ctx.Err()).Str("rpc", queryNode.ServerAddress).Msg("Waiting to check stake status failed")
 		return false, ctx.Err()
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description
* Registration was waiting two blocks hardcoded for the tx to be accepted. This would affect when block times have a disparity with the actual block times. 
Solved by parameterising the number of blocks in `RegistrationWaitingBlocks`. 

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed. -- unit tests only so far.
- [x] If documented, please describe where. If not, describe why docs are not needed. -- definition documented in params section definition.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?


