### PR TITLE
Ability to set FeeGrantAddress when signing transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#129](https://github.com/allora-network/allora-offchain-node/pull/129) Update v0.12.0 chain dependencies
 * [#130](https://github.com/allora-network/allora-offchain-node/pull/130) Add error-level metrics, clean existing metrics
+* [#128](https://github.com/allora-network/allora-offchain-node/pull/128) Ability to set FeeGrantAddress when signing transactions
 
 ### Changed
 

--- a/config.cdk.json.template
+++ b/config.cdk.json.template
@@ -3,6 +3,7 @@
       "addressKeyName": "_ALLORA_WALLET_ADDRESS_KEY_NAME_",
       "addressRestoreMnemonic": "_ALLORA_WALLET_ADDRESS_RESTORE_MNEMONIC_",
       "alloraHomeDir": "_ALLORA_WALLET_HOME_DIR_",
+      "feeGranterAddress": "_ALLORA_FEE_GRANTER_ADDRESS_",
       "gas": "_ALLORA_WALLET_GAS_",
       "gasAdjustment": _ALLORA_WALLET_GAS_ADJUSTMENT_,
       "gasPrices": "_ALLORA_WALLET_GAS_PRICES_",

--- a/config.example.json
+++ b/config.example.json
@@ -5,6 +5,7 @@
       "keyringPassphrase": "",
       "addressKeyName": "testkey",
       "addressRestoreMnemonic": "your mnemonic here",
+      "feeGranterAddress": "",
       "alloraHomeDir": "",
       "gasPrices": "auto",
       "gasPriceUpdateInterval": 5,

--- a/lib/domain_config.go
+++ b/lib/domain_config.go
@@ -49,8 +49,9 @@ const (
 // Properties manually provided by the user as part of UserConfig
 type WalletConfig struct {
 	// Provided by the user
-	AddressKeyName                string                  // load a address by key from the keystore
-	AddressRestoreMnemonic        string                  // load a address by mnemonic from the keystore
+	AddressKeyName                string                  // load an address by key from the keystore
+	AddressRestoreMnemonic        string                  // load an address by mnemonic from the keystore
+	FeeGranterAddress             string                  // if set, the address from a fee granter will be used to sign transactions (see x/feegranter)
 	AlloraHomeDir                 string                  // home directory for the allora keystore
 	ChainId                       string                  // chain id
 	KeyringBackend                string                  // keyring backend to use ("test", "os", "file", ...)

--- a/lib/repo_tx_utils.go
+++ b/lib/repo_tx_utils.go
@@ -47,6 +47,7 @@ func (connectionManager *ConnectionManager) SendDataWithRetry(ctx context.Contex
 			OverrideGas:   0,
 			OverrideFees:  0,
 		},
+		FeeGranterAddress: walletConfig.FeeGranterAddress,
 	}
 
 	txNode, err := connectionManager.GetCurrentTxNode()

--- a/lib/transaction/builder.go
+++ b/lib/transaction/builder.go
@@ -79,6 +79,15 @@ func BuildAndSignTransaction(
 	feeCoin := sdktypes.NewCoin(txParams.Denom, fees)
 	txBuilder.SetFeeAmount(sdktypes.NewCoins(feeCoin))
 
+	// Set fee granter (optional)
+	if txParams.FeeGranterAddress != "" {
+		granterAddr, err := sdktypes.AccAddressFromBech32(txParams.FeeGranterAddress)
+		if err != nil {
+			return nil, err
+		}
+		txBuilder.SetFeeGranter(granterAddr)
+	}
+
 	// Set memo and timeout height
 	txBuilder.SetMemo(memo)
 	txBuilder.SetTimeoutHeight(txParams.TimeoutHeight)

--- a/lib/transaction/builder.go
+++ b/lib/transaction/builder.go
@@ -4,6 +4,7 @@ import (
 	"allora_offchain_node/lib/rpcclient"
 	types "allora_offchain_node/lib/types"
 	"context"
+	"fmt"
 	gomath "math"
 
 	"cosmossdk.io/math"
@@ -83,7 +84,7 @@ func BuildAndSignTransaction(
 	if txParams.FeeGranterAddress != "" {
 		granterAddr, err := sdktypes.AccAddressFromBech32(txParams.FeeGranterAddress)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to parse fee granter address %v: %w", txParams.FeeGranterAddress, err)
 		}
 		txBuilder.SetFeeGranter(granterAddr)
 	}

--- a/lib/transaction/builder_test.go
+++ b/lib/transaction/builder_test.go
@@ -74,6 +74,7 @@ func TestBuildAndSignTransactionWithDifferentParams(t *testing.T) {
 					OverrideFees:  0,
 					SimulateTx:    false,
 				},
+				FeeGranterAddress: "",
 			},
 			sequence: 0,
 			msgs: []sdktypes.Msg{&emissionstypes.RegisterRequest{
@@ -105,6 +106,7 @@ func TestBuildAndSignTransactionWithDifferentParams(t *testing.T) {
 					OverrideFees:  0,
 					SimulateTx:    false,
 				},
+				FeeGranterAddress: "",
 			},
 			sequence: 0,
 			msgs: []sdktypes.Msg{&emissionstypes.RegisterRequest{
@@ -136,6 +138,7 @@ func TestBuildAndSignTransactionWithDifferentParams(t *testing.T) {
 					SimulateTx:    false,
 					GasAdjustment: 1.2,
 				},
+				FeeGranterAddress: "",
 			},
 			sequence: 0,
 			msgs: []sdktypes.Msg{&emissionstypes.RegisterRequest{
@@ -167,6 +170,7 @@ func TestBuildAndSignTransactionWithDifferentParams(t *testing.T) {
 					OverrideFees:  0,
 					SimulateTx:    false,
 				},
+				FeeGranterAddress: "",
 			},
 			sequence: 0,
 			msgs: []sdktypes.Msg{
@@ -206,6 +210,7 @@ func TestBuildAndSignTransactionWithDifferentParams(t *testing.T) {
 					OverrideFees:  0,
 					SimulateTx:    false,
 				},
+				FeeGranterAddress: "",
 			},
 			sequence: 0,
 			msgs: []sdktypes.Msg{&emissionstypes.RegisterRequest{
@@ -237,6 +242,7 @@ func TestBuildAndSignTransactionWithDifferentParams(t *testing.T) {
 					OverrideFees:  0,
 					SimulateTx:    false,
 				},
+				FeeGranterAddress: "",
 			},
 			sequence: 0,
 			msgs: []sdktypes.Msg{&emissionstypes.RegisterRequest{

--- a/lib/transaction/builder_test.go
+++ b/lib/transaction/builder_test.go
@@ -191,6 +191,38 @@ func TestBuildAndSignTransactionWithDifferentParams(t *testing.T) {
 			errMessage: "",
 		},
 		{
+			name: "Using a fee granter address",
+			txParams: &types.TransactionParams{
+				ChainID:       "test-chain",
+				Denom:         "utest",
+				Prefix:        "test",
+				Sequence:      0,
+				AccNum:        1,
+				PrivKey:       privKey,
+				PubKey:        pubKey,
+				TimeoutHeight: 0,
+				GasEstimationConfig: types.GasEstimationConfig{
+					BaseGas:       2000,
+					GasPerByte:    10,
+					MinGasPrice:   0.1,
+					GasAdjustment: 1.2,
+					OverrideGas:   0,
+					OverrideFees:  0,
+					SimulateTx:    false,
+				},
+				FeeGranterAddress: "allo1urp932djsx64c0suy5r4w5f50teu43c3dgw5me",
+			},
+			sequence: 0,
+			msgs: []sdktypes.Msg{&emissionstypes.RegisterRequest{
+				Sender:    addr,
+				TopicId:   1,
+				Owner:     addr,
+				IsReputer: false,
+			}},
+			expectErr:  false,
+			errMessage: "",
+		},
+		{
 			name: "Edge case - zero gas price",
 			txParams: &types.TransactionParams{
 				ChainID:       "test-chain",
@@ -254,7 +286,43 @@ func TestBuildAndSignTransactionWithDifferentParams(t *testing.T) {
 			expectErr:  true,
 			errMessage: "gas overflow",
 		},
+		{
+			name: "Edge case - invalid fee granter address",
+			txParams: &types.TransactionParams{
+				ChainID:       "test-chain",
+				Denom:         "utest",
+				Prefix:        "test",
+				Sequence:      0,
+				AccNum:        1,
+				PrivKey:       privKey,
+				PubKey:        pubKey,
+				TimeoutHeight: 0,
+				GasEstimationConfig: types.GasEstimationConfig{
+					BaseGas:       2000,
+					GasPerByte:    10,
+					MinGasPrice:   0.1,
+					GasAdjustment: 1.2,
+					OverrideGas:   0,
+					OverrideFees:  0,
+					SimulateTx:    false,
+				},
+				FeeGranterAddress: "muah1urp932djsx64c0suy5r4w5f50teu43c3dgw5me",
+			},
+			sequence: 0,
+			msgs: []sdktypes.Msg{&emissionstypes.RegisterRequest{
+				Sender:    addr,
+				TopicId:   1,
+				Owner:     addr,
+				IsReputer: false,
+			}},
+			expectErr:  true,
+			errMessage: "failed to parse fee granter address muah1urp932djsx64c0suy5r4w5f50teu43c3dgw5me: decoding bech32 failed: invalid checksum",
+		},
 	}
+
+	config := sdktypes.GetConfig()
+	config.SetBech32PrefixForAccount("allo", "allo")
+	config.Seal()
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/lib/types/txparams.go
+++ b/lib/types/txparams.go
@@ -16,6 +16,7 @@ type TransactionParams struct {
 	PubKey              cryptotypes.PubKey
 	TimeoutHeight       uint64
 	GasEstimationConfig GasEstimationConfig
+	FeeGranterAddress   string
 }
 
 // GasEstimationConfig holds the parameters used for gas estimation.


### PR DESCRIPTION
## Purpose of Changes and their Description

Set FeeGrantAddress when signing reputer and worker/forecaster transactions

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

ENGN-3546

https://linear.app/alloralabs/issue/ENGN-3546/offchain-node-utilize-xfeegrant-module-in-workersreputersforecasters

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [x] If documented, please describe where. If not, describe why docs are not needed.
- [x] Added to `Unreleased` section of `CHANGELOG.md`?

--

Documented the go code